### PR TITLE
Fix mistaken -[NSMutableData dataWithCapacity:]

### DIFF
--- a/Foundation/GTMNSString+HTML.m
+++ b/Foundation/GTMNSString+HTML.m
@@ -381,7 +381,7 @@ static int EscapeMapCompare(const void *ucharVoid, const void *mapVoid) {
   }
   
   NSMutableString *finalString = [NSMutableString string];
-  NSMutableData *data2 = [NSMutableData dataWithCapacity:sizeof(unichar) * length];
+  NSMutableData *data2 = [NSMutableData dataWithLength:sizeof(unichar) * length];
 
   // this block is common between GTMNSString+HTML and GTMNSString+XML but
   // it's so short that it isn't really worth trying to share.

--- a/Foundation/GTMNSString+HTML.m
+++ b/Foundation/GTMNSString+HTML.m
@@ -385,10 +385,10 @@ static int EscapeMapCompare(const void *ucharVoid, const void *mapVoid) {
 
   // this block is common between GTMNSString+HTML and GTMNSString+XML but
   // it's so short that it isn't really worth trying to share.
-  const unichar *buffer = CFStringGetCharactersPtr((CFStringRef)self);
+  const unichar *buffer = NULL; //CFStringGetCharactersPtr((CFStringRef)self);
   if (!buffer) {
     // We want this buffer to be autoreleased.
-    NSMutableData *data = [NSMutableData dataWithLength:length * sizeof(UniChar)];
+    NSMutableData *data = [NSMutableData dataWithLength:length * sizeof(unichar)];
     if (!data) {
       // COV_NF_START  - Memory fail case
       _GTMDevLog(@"couldn't alloc buffer");
@@ -416,9 +416,11 @@ static int EscapeMapCompare(const void *ucharVoid, const void *mapVoid) {
                                  sizeof(HTMLEscapeMap), EscapeMapCompare);
     if (val || (escapeUnicode && buffer[i] > 127)) {
       if (buffer2Length) {
-        CFStringAppendCharacters((CFMutableStringRef)finalString, 
+      [finalString appendString:[NSString stringWithCharacters:buffer2
+                                                        length:buffer2Length]];
+/*        CFStringAppendCharacters((CFMutableStringRef)finalString,
                                  buffer2, 
-                                 buffer2Length);
+                                 buffer2Length);*/
         buffer2Length = 0;
       }
       if (val) {
@@ -434,9 +436,11 @@ static int EscapeMapCompare(const void *ucharVoid, const void *mapVoid) {
     }
   }
   if (buffer2Length) {
-    CFStringAppendCharacters((CFMutableStringRef)finalString, 
+      [finalString appendString:[NSString stringWithCharacters:buffer2
+                                                        length:buffer2Length]];
+/*    CFStringAppendCharacters((CFMutableStringRef)finalString,
                              buffer2, 
-                             buffer2Length);
+                             buffer2Length);*/
   }
   return finalString;
 }

--- a/GTMDefines.h
+++ b/GTMDefines.h
@@ -22,7 +22,9 @@
 #include <TargetConditionals.h>
 
 #ifdef __OBJC__
-#include <Foundation/NSObjCRuntime.h>
+# ifndef __MULLE_OBJC_RUNTIME__
+#  include <Foundation/NSObjCRuntime.h>
+# endif
 #endif  // __OBJC__
 
 #if TARGET_OS_IPHONE

--- a/GTMDefines.h
+++ b/GTMDefines.h
@@ -18,8 +18,10 @@
 
 // ============================================================================
 
-#include <AvailabilityMacros.h>
-#include <TargetConditionals.h>
+#ifdef __APPLE__
+# include <AvailabilityMacros.h>
+# include <TargetConditionals.h>
+#endif
 
 #ifdef __OBJC__
 # ifndef __MULLE_OBJC_RUNTIME__


### PR DESCRIPTION
The original code is wrong, because  `+dataWithCapacity:` does not need to allocate the capacity already. The subsequent `-mutableBytes` call may return NULL.
