### PR TITLE
Improve the casing macros

### DIFF
--- a/DebugUtils/GTMTypeCasting.h
+++ b/DebugUtils/GTMTypeCasting.h
@@ -1,14 +1,14 @@
 //
 //  GTMTypeCasting.h
-//  
+//
 //  Copyright 2010 Google Inc.
 //
 //  Licensed under the Apache License, Version 2.0 (the "License"); you may not
 //  use this file except in compliance with the License.  You may obtain a copy
 //  of the License at
-// 
+//
 //  http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 //  Unless required by applicable law or agreed to in writing, software
 //  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
 //  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
@@ -58,14 +58,14 @@ GTM_INLINE id GTMStaticCastSupport(Class cls, id object) {
 
 #ifndef GTM_STATIC_CAST
   #ifdef DEBUG
-    #define GTM_STATIC_CAST(type, object) GTMStaticCastSupport([type class], \
-                                                               object)
+    #define GTM_STATIC_CAST(type, object) \
+      ((type *) GTMStaticCastSupport([type class], object))
   #else
     #define GTM_STATIC_CAST(type, object) ((type *) (object))
   #endif
 #endif
 
 #ifndef GTM_DYNAMIC_CAST
-  #define GTM_DYNAMIC_CAST(type, object) GTMDynamicCastSupport([type class], \
-                                                               object)
+  #define GTM_DYNAMIC_CAST(type, object) \
+    ((type *) GTMDynamicCastSupport([type class], object))
 #endif


### PR DESCRIPTION
Make GTM_STATIC_CAST(className, object) and GTM_DYNAMIC_CAST(className, object)
return objects that are type-casted to className *, instead of id. This enables
access to properties on the casted objects, e.g.

  GTM_STATIC_CAST(NSString, object).length

which wouldn't work previously, since accessing .length on an id type
(correctly) results in a compiler error.