### PR TITLE
10.13 SDK (and iOS 11 equivalent) compatibility for GTM

### DIFF
--- a/AppKit/GTMCarbonEvent.m
+++ b/AppKit/GTMCarbonEvent.m
@@ -94,8 +94,8 @@
 //
 - (id)initWithClass:(UInt32)inClass kind:(UInt32)kind {
   if ((self = [super init])) {
-    verify_noerr(CreateEvent(kCFAllocatorDefault, inClass, kind,
-                             0, kEventAttributeNone, &event_));
+    __Verify_noErr(CreateEvent(kCFAllocatorDefault, inClass, kind,
+                               0, kEventAttributeNone, &event_));
   }
   return self;
 }
@@ -186,7 +186,7 @@
 //    time - the time you want associated with the event
 //
 - (void)setTime:(EventTime)eventTime {
-  verify_noerr(SetEventTime(event_, eventTime));
+  __Verify_noErr(SetEventTime(event_, eventTime));
 }
 
 
@@ -243,16 +243,16 @@
 //  Post event to current queue with standard priority.
 //
 - (void)postToCurrentQueue {
-  verify_noerr([self postToQueue:GetCurrentEventQueue()
-                        priority:kEventPriorityStandard]);
+  __Verify_noErr([self postToQueue:GetCurrentEventQueue()
+                          priority:kEventPriorityStandard]);
 }
 
 
 //  Post event to main queue with standard priority.
 //
 - (void)postToMainQueue {
-  verify_noerr([self postToQueue:GetMainEventQueue()
-                        priority:kEventPriorityStandard]);
+  __Verify_noErr([self postToQueue:GetMainEventQueue()
+                          priority:kEventPriorityStandard]);
 }
 
 
@@ -269,7 +269,7 @@
                      type:(EventParamType)type
                      size:(ByteCount)size
                      data:(const void *)data {
-  verify_noerr(SetEventParameter(event_, name, type, size, data));
+  __Verify_noErr(SetEventParameter(event_, name, type, size, data));
 }
 
 
@@ -308,7 +308,7 @@
 - (ByteCount)sizeOfParameterNamed:(EventParamName)name
                              type:(EventParamType)type {
   ByteCount size = 0;
-  verify_noerr(GetEventParameter(event_, name, type, NULL, 0, &size, NULL));
+  __Verify_noErr(GetEventParameter(event_, name, type, NULL, 0, &size, NULL));
   return size;
 }
 
@@ -345,7 +345,7 @@ const OSType kGTMCarbonFrameworkSignature = 'GTM ';
 
 -(void)dealloc {
   if (eventHandler_) {
-    verify_noerr(RemoveEventHandler(eventHandler_));
+    __Verify_noErr(RemoveEventHandler(eventHandler_));
   }
   [super dealloc];
 }
@@ -364,7 +364,7 @@ const OSType kGTMCarbonFrameworkSignature = 'GTM ';
 //   count - the number of EventTypeSpecs in events.
 //
 - (void)registerForEvents:(const EventTypeSpec *)events count:(size_t)count {
-  verify_noerr(AddEventTypesToHandler([self eventHandler], count, events));
+  __Verify_noErr(AddEventTypesToHandler([self eventHandler], count, events));
 }
 
 // Causes the event handler to stop listening for |events|.
@@ -374,7 +374,8 @@ const OSType kGTMCarbonFrameworkSignature = 'GTM ';
 //   count - the number of EventTypeSpecs in events.
 //
 - (void)unregisterForEvents:(const EventTypeSpec *)events count:(size_t)count {
-  verify_noerr(RemoveEventTypesFromHandler([self eventHandler], count, events));
+  __Verify_noErr(
+      RemoveEventTypesFromHandler([self eventHandler], count, events));
 }
 
 // To be overridden by subclasses to respond to events. All subclasses should
@@ -390,9 +391,9 @@ const OSType kGTMCarbonFrameworkSignature = 'GTM ';
 - (OSStatus)handleEvent:(GTMCarbonEvent *)event
                 handler:(EventHandlerCallRef)handler {
   OSStatus status = eventNotHandledErr;
-  require(event, CantUseParams);
-  require(handler, CantUseParams);
-  require([event event], CantUseParams);
+  __Require(event, CantUseParams);
+  __Require(handler, CantUseParams);
+  __Require([event event], CantUseParams);
   status = CallNextEventHandler(handler, [event event]);
 CantUseParams:
   return status;
@@ -452,9 +453,9 @@ static OSStatus EventHandler(EventHandlerCallRef inHandler,
     if ( sHandlerProc == NULL ) {
       sHandlerProc = NewEventHandlerUPP(EventHandler);
     }
-    verify_noerr(InstallEventHandler([self eventTarget],
-                                     sHandlerProc, 0,
-                                     NULL, self, &eventHandler_));
+    __Verify_noErr(InstallEventHandler([self eventTarget],
+                                       sHandlerProc, 0,
+                                       NULL, self, &eventHandler_));
   }
   return eventHandler_;
 }
@@ -590,14 +591,14 @@ extern EventTargetRef GetApplicationEventTarget(void);
                                              action:selector
                                            userInfo:userInfo
                                         whenPressed:onKeyDown] autorelease];
-  require(newKey, CantCreateKey);
-  require_noerr_action(RegisterEventHotKey((UInt32)keyCode,
-                                           GTMCocoaToCarbonKeyModifiers(cocoaModifiers),
-                                           keyID,
-                                           [self eventTarget],
-                                           0,
-                                           &theRef),
-                       CantRegisterHotKey, newKey = nil);
+  __Require(newKey, CantCreateKey);
+  __Require_noErr_Action(RegisterEventHotKey((UInt32)keyCode,
+                                             GTMCocoaToCarbonKeyModifiers(cocoaModifiers),
+                                             keyID,
+                                             [self eventTarget],
+                                             0,
+                                             &theRef),
+                         CantRegisterHotKey, newKey = nil);
   [newKey setHotKeyRef:theRef];
   [hotkeys_ addObject:newKey];
 
@@ -610,10 +611,10 @@ CantCreateKey:
 //  Arguments:
 //    keyRef - the EventHotKeyRef to unregister
 - (void)unregisterHotKey:(GTMCarbonHotKey *)keyRef {
-  check([hotkeys_ containsObject:keyRef]);
+  __Check([hotkeys_ containsObject:keyRef]);
   [[keyRef retain] autorelease];
   [hotkeys_ removeObject:keyRef];
-  verify_noerr(UnregisterEventHotKey([keyRef hotKeyRef]));
+  __Verify_noErr(UnregisterEventHotKey([keyRef hotKeyRef]));
 }
 
 // A hotkey has been hit. See if it is one of ours, and if so fire it.

--- a/Foundation/GTMNSFileManager+Carbon.m
+++ b/Foundation/GTMNSFileManager+Carbon.m
@@ -28,10 +28,10 @@
   FSRef ref;
   AliasHandle alias = NULL;
 
-  require_quiet([path length], CantUseParams);
-  require_noerr(FSPathMakeRef((UInt8 *)[path fileSystemRepresentation],
-                              &ref, NULL), CantMakeRef);
-  require_noerr(FSNewAlias(NULL, &ref, &alias), CantMakeAlias);
+  __Require_Quiet([path length], CantUseParams);
+  __Require_noErr(FSPathMakeRef((UInt8 *)[path fileSystemRepresentation],
+                                &ref, NULL), CantMakeRef);
+  __Require_noErr(FSNewAlias(NULL, &ref, &alias), CantMakeAlias);
 
   Size length = GetAliasSize(alias);
   data = [NSData dataWithBytes:*alias length:length];
@@ -52,12 +52,12 @@ CantUseParams:
                             resolve:(BOOL)resolve
                              withUI:(BOOL)withUI {
   NSString *path = nil;
-  require_quiet(data, CantUseParams);
+  __Require_Quiet(data, CantUseParams);
 
   AliasHandle alias;
   const void *bytes = [data bytes];
   NSUInteger length = [data length];
-  require_noerr(PtrToHand(bytes, (Handle *)&alias, length), CantMakeHandle);
+  __Require_noErr(PtrToHand(bytes, (Handle *)&alias, length), CantMakeHandle);
 
   FSRef ref;
   Boolean wasChanged;
@@ -85,14 +85,14 @@ CantUseParams:
 
 - (FSRef *)gtm_FSRefForPath:(NSString *)path {
   FSRef* fsRef = NULL;
-  require_quiet([path length], CantUseParams);
+  __Require_Quiet([path length], CantUseParams);
   NSMutableData *fsRefData = [NSMutableData dataWithLength:sizeof(FSRef)];
-  require(fsRefData, CantAllocateFSRef);
+  __Require(fsRefData, CantAllocateFSRef);
   fsRef = (FSRef*)[fsRefData mutableBytes];
   Boolean isDir = FALSE;
   const UInt8 *filePath = (const UInt8 *)[path fileSystemRepresentation];
-  require_noerr_action(FSPathMakeRef(filePath, fsRef, &isDir),
-                       CantMakeRef, fsRef = NULL);
+  __Require_noErr_action(FSPathMakeRef(filePath, fsRef, &isDir),
+                         CantMakeRef, fsRef = NULL);
 CantMakeRef:
 CantAllocateFSRef:
 CantUseParams:
@@ -101,10 +101,11 @@ CantUseParams:
 
 - (NSString *)gtm_pathFromFSRef:(FSRef *)fsRef {
   NSString *nsPath = nil;
-  require_quiet(fsRef, CantUseParams);
+  __Require_Quiet(fsRef, CantUseParams);
 
   char path[MAXPATHLEN];
-  require_noerr(FSRefMakePath(fsRef, (UInt8 *)path, MAXPATHLEN), CantMakePath);
+  __Require_noErr(FSRefMakePath(fsRef, (UInt8 *)path, MAXPATHLEN),
+                  CantMakePath);
   nsPath = [self stringWithFileSystemRepresentation:path length:strlen(path)];
   nsPath = [nsPath stringByStandardizingPath];
 

--- a/Foundation/GTMServiceManagement.c
+++ b/Foundation/GTMServiceManagement.c
@@ -88,9 +88,9 @@ static bool IsOsYosemiteOrGreater() {
 #else
   SInt32 version_major;
   SInt32 version_minor;
-  require_noerr(Gestalt(gestaltSystemVersionMajor, &version_major),
+  __Require_noErr(Gestalt(gestaltSystemVersionMajor, &version_major),
       failedGestalt);
-  require_noerr(Gestalt(gestaltSystemVersionMinor, &version_minor),
+  __Require_noErr(Gestalt(gestaltSystemVersionMinor, &version_minor),
       failedGestalt);
   return version_major > 10 || (version_major == 10 && version_minor >= 10);
   failedGestalt:

--- a/Foundation/GTMSystemVersion.m
+++ b/Foundation/GTMSystemVersion.m
@@ -50,9 +50,12 @@ static NSString *const kSystemVersionPlistPath = @"/System/Library/CoreServices/
     // <http://lists.apple.com/archives/carbon-dev/2007/Aug/msg00089.html>).
     // The iPhone doesn't have Gestalt though, so use the plist there.
 #if GTM_MACOS_SDK
-    require_noerr(Gestalt(gestaltSystemVersionMajor, &sGTMSystemVersionMajor), failedGestalt);
-    require_noerr(Gestalt(gestaltSystemVersionMinor, &sGTMSystemVersionMinor), failedGestalt);
-    require_noerr(Gestalt(gestaltSystemVersionBugFix, &sGTMSystemVersionBugFix), failedGestalt);
+    __Require_noErr(Gestalt(gestaltSystemVersionMajor,
+                            &sGTMSystemVersionMajor), failedGestalt);
+    __Require_noErr(Gestalt(gestaltSystemVersionMinor,
+                            &sGTMSystemVersionMinor), failedGestalt);
+    __Require_noErr(Gestalt(gestaltSystemVersionBugFix,
+                            &sGTMSystemVersionBugFix), failedGestalt);
 
     return;
 

--- a/UnitTesting/GTMAppKitUnitTestingUtilities.m
+++ b/UnitTesting/GTMAppKitUnitTestingUtilities.m
@@ -62,12 +62,12 @@ static CGKeyCode GTMKeyCodeForCharCode(CGCharCode charCode);
 + (void)postKeyEvent:(NSEventType)type
            character:(CGCharCode)keyChar
            modifiers:(UInt32)cocoaModifiers {
-  require(![self isScreenSaverActive], CantWorkWithScreenSaver);
-  require(type == NSKeyDown || type == NSKeyUp, CantDoEvent);
+  __Require(![self isScreenSaverActive], CantWorkWithScreenSaver);
+  __Require(type == NSKeyDown || type == NSKeyUp, CantDoEvent);
   CGKeyCode code = GTMKeyCodeForCharCode(keyChar);
-  verify(code != 256);
+  __Verify(code != 256);
   CGEventRef event = CGEventCreateKeyboardEvent(NULL, code, type == NSKeyDown);
-  require(event, CantCreateEvent);
+  __Require(event, CantCreateEvent);
   CGEventSetFlags(event, cocoaModifiers);
   CGEventPost(kCGSessionEventTap, event);
   CFRelease(event);


### PR DESCRIPTION
Starting in the 10.6 SDK, the non-underscored and all-lowercase macro
names in <AssertMacros.h> were deprecated. In the 10.13 SDK shipping in
Xcode 9 beta 3 (but not previous betas of Xcode 9), Apple has made good
on its promise to eventually disable these names. Update GTM to use the
new underscored mixed-case names.

Provided that nobody needs to target anything older than the 10.5 SDK
anymore, this should be a safe change.

Aside from GTMCarbonEvent.m, which is used by Chrome, this change is
untested, and was made by mechanically replacing uses of the various
check, require, and verify macros found in GTM.