### PR TITLE
Cast NSInteger to long for formatting as %ld

### DIFF
--- a/Foundation/GTMGeometryUtilsTest.m
+++ b/Foundation/GTMGeometryUtilsTest.m
@@ -125,7 +125,7 @@
     NSRect result = GTMNSScaleRectangleToSize(rect, tests[i].size_,
                                               GTMScaleProportionally);
     XCTAssertTrue(NSEqualRects(result, GTMNSRectOfSize(tests[i].newSize_)),
-                  @"failed on test %zd", i);
+                  @"failed on test %zu", i);
   }
 
   NSRect result = GTMNSScaleRectangleToSize(NSZeroRect, tests[0].size_,
@@ -288,7 +288,7 @@
     CGRect result = GTMCGScaleRectangleToSize(rect, tests[i].size_,
                                               GTMScaleProportionally);
     XCTAssertTrue(CGRectEqualToRect(result, GTMCGRectOfSize(tests[i].newSize_)),
-                  @"failed on test %zd", i);
+                  @"failed on test %zu", i);
   }
 
   CGRect result = GTMCGScaleRectangleToSize(CGRectZero, tests[0].size_,

--- a/Foundation/GTMRegex.m
+++ b/Foundation/GTMRegex.m
@@ -410,7 +410,7 @@ static NSString *const kReplacementPattern =
 
 - (NSString *)description {
   NSMutableString *result =
-    [NSMutableString stringWithFormat:@"%@<%p> { pattern=\"%@\", rawNumSubPatterns=%zd, options=(",
+    [NSMutableString stringWithFormat:@"%@<%p> { pattern=\"%@\", rawNumSubPatterns=%zu, options=(",
       [self class], self, pattern_, regexData_.re_nsub];
   if (options_) {
     if (options_ & kGTMRegexOptionIgnoreCase)

--- a/UnitTesting/GTMSenTestCase.h
+++ b/UnitTesting/GTMSenTestCase.h
@@ -223,7 +223,7 @@
     } else if (![_a2value isKindOfClass:[NSString class]]) { \
       _failure = [NSString stringWithFormat:@"(%@) is not an NSString* (%@)", @#a2, [_a2value class]]; \
     } else if ((_result = [_a1value compare:_a2value]) != NSOrderedSame) { \
-      _failure = [NSString stringWithFormat:@"(%@) vs (%@) == %zd", _a1value, _a2value, (long)_result]; \
+      _failure = [NSString stringWithFormat:@"(%@) vs (%@) == %ld", _a1value, _a2value, (long)_result]; \
     } \
   } \
   @catch (NSException *_exception) { \
@@ -263,7 +263,7 @@
     } else if (![_a2value isKindOfClass:[NSString class]]) { \
       _failure = [NSString stringWithFormat:@"(%@) is not an NSString* (%@)", @#a2, [_a2value class]]; \
     } else if ((_result = [_a1value compare:_a2value]) == NSOrderedSame) { \
-      _failure = [NSString stringWithFormat:@"(%@) vs (%@) == %zd", _a1value, _a2value, _result]; \
+      _failure = [NSString stringWithFormat:@"(%@) vs (%@) == %ld", _a1value, _a2value, (long)_result]; \
     } \
   } \
   @catch (NSException *_exception) { \

--- a/iPhone/GTMUIImage+Resize.m
+++ b/iPhone/GTMUIImage+Resize.m
@@ -152,7 +152,7 @@ GTM_INLINE CGSize swapWidthAndHeight(CGSize size) {
       break;
 
     default:
-      _GTMDevAssert(false, @"Invalid orientation %zd", orientation);
+      _GTMDevAssert(false, @"Invalid orientation %ld", (long)orientation);
       return nil;
   }
 


### PR DESCRIPTION
In https://crbug.com/747643, a new version of Clang produces warnings
when attempting to format NSInteger as %zd (which is normally used for
ssize_t). Acquiesce by casting NSInteger to long and formatting using
%ld.

In the process, I audited all occurrences of %zd in GTM and found that
the remainder were being used to format size_t, which ought to use %zu,
so I’ve corrected those.

I also audited the existing uses of %zu and found them all to be
correct.