### PR TITLE
Add support to unescape &#128077;

### DIFF
--- a/Foundation/GTMNSString+HTML.m
+++ b/Foundation/GTMNSString+HTML.m
@@ -486,12 +486,14 @@ static int EscapeMapCompare(const void *ucharVoid, const void *mapVoid) {
           NSScanner *scanner = [NSScanner scannerWithString:hexSequence];
           unsigned value;
           if ([scanner scanHexInt:&value] &&
-              value < USHRT_MAX &&
+              value < INT_MAX &&
               value > 0
               && [scanner scanLocation] == length - 4) {
-            unichar uchar = (unichar)value;
-            NSString *charString = [NSString stringWithCharacters:&uchar length:1];
-            [finalString replaceCharactersInRange:escapeRange withString:charString];
+            value = NSSwapHostIntToLittle(value);
+            NSString *charString = [[NSString alloc] initWithBytes:&value length:sizeof(value) encoding:NSUTF32LittleEndianStringEncoding];
+            if (charString) {
+              [finalString replaceCharactersInRange:escapeRange withString:charString];
+            }
           }
 
         } else {
@@ -500,12 +502,14 @@ static int EscapeMapCompare(const void *ucharVoid, const void *mapVoid) {
           NSScanner *scanner = [NSScanner scannerWithString:numberSequence];
           int value;
           if ([scanner scanInt:&value] &&
-              value < USHRT_MAX &&
+              value < INT_MAX &&
               value > 0
               && [scanner scanLocation] == length - 3) {
-            unichar uchar = (unichar)value;
-            NSString *charString = [NSString stringWithCharacters:&uchar length:1];
-            [finalString replaceCharactersInRange:escapeRange withString:charString];
+            value = NSSwapHostIntToLittle(value);
+            NSString *charString = [[NSString alloc] initWithBytes:&value length:sizeof(value) encoding:NSUTF32LittleEndianStringEncoding];
+            if (charString) {
+              [finalString replaceCharactersInRange:escapeRange withString:charString];
+            }
           }
         }
       } else {

--- a/Foundation/GTMNSString+HTMLTest.m
+++ b/Foundation/GTMNSString+HTMLTest.m
@@ -226,6 +226,8 @@
   XCTAssertEqualObjects([@"&lt;this &amp; that&gt;" gtm_stringByUnescapingFromHTML],
                         @"<this & that>", @"HTML unescaping failed");
 
+  XCTAssertEqualObjects([@"&#128077;" gtm_stringByUnescapingFromHTML],
+                        @"👍", @"HTML unescaping failed");
 
 } // testStringByUnescapingHTML
 

--- a/Foundation/GTMNSString+HTMLTest.m
+++ b/Foundation/GTMNSString+HTMLTest.m
@@ -226,8 +226,11 @@
   XCTAssertEqualObjects([@"&lt;this &amp; that&gt;" gtm_stringByUnescapingFromHTML],
                         @"<this & that>", @"HTML unescaping failed");
 
-  XCTAssertEqualObjects([@"&#128077;" gtm_stringByUnescapingFromHTML],
-                        @"👍", @"HTML unescaping failed");
+  XCTAssertEqualObjects([@"&#x10437;" gtm_stringByUnescapingFromHTML],
+                        @"𐐷", @"HTML unescaping failed");
+
+  XCTAssertEqualObjects([@"&#66615;" gtm_stringByUnescapingFromHTML],
+                        @"𐐷", @"HTML unescaping failed");
 
 } // testStringByUnescapingHTML
 


### PR DESCRIPTION
This pull request is to enable gtm_stringByUnescapingFromHTML to unescape number sequence above 65535, such as `&#128077;` (which is 👍).