### PR TITLE
Allow for building GTMSystemVersion under deployment target of 10.8 a…

### DIFF
--- a/Foundation/GTMSystemVersionTest.m
+++ b/Foundation/GTMSystemVersionTest.m
@@ -90,4 +90,30 @@
   XCTAssertTrue([GTMSystemVersion isBuildLessThan:largeVersion]);
 
 }
+
+#ifdef GTM_MACOS_SDK
+- (void)testMacOSVersion {
+  SInt32 major = -1;
+  SInt32 minor = -1;
+  SInt32 bugfix = -1;
+
+  [GTMSystemVersion getMajor:&major minor:&minor bugFix:&bugfix];
+  NSDictionary *versionPlistContents =
+      [NSDictionary dictionaryWithContentsOfFile:
+          @"/System/Library/CoreServices/SystemVersion.plist"];
+  XCTAssertNotNil(versionPlistContents);
+  NSString *version =
+      [versionPlistContents objectForKey:@"ProductVersion"];
+  XCTAssertNotNil(version);
+  NSArray *pieces = [version componentsSeparatedByString:@"."];
+  XCTAssertTrue([pieces count] > 2);
+  XCTAssertEqual(major, (SInt32)[[pieces objectAtIndex:0] integerValue]);
+  XCTAssertEqual(minor, [[pieces objectAtIndex:1] integerValue]);
+  if ([pieces count] > 2) {
+    XCTAssertEqual(bugfix, [[pieces objectAtIndex:2] integerValue]);
+  } else {
+    XCTAssertEqual(bugfix, 0, @"possible beta OS");
+  }
+}
+#endif
 @end


### PR DESCRIPTION
Allow for building GTMSystemVersion under deployment target of 10.8 and above.
- Keep Gestalt APIs till 10.8.
- On 10.8 and 10.9 use sysctl and infer the OS version from there.
- On 10.10+ use NSProcessInfo.
- Added unit test to cover it.