### PR TITLE
iOS: add missing linker flags to preserve categories methods in the linked binary

### DIFF
--- a/XcodeConfig/subconfig/iOS.xcconfig
+++ b/XcodeConfig/subconfig/iOS.xcconfig
@@ -19,5 +19,5 @@
 
 // Set default SDK.
 SDKROOT = iphoneos
-
+GTM_PLATFORM_OTHER_LDFLAGS = -ObjC
 // Use IPHONEOS_DEPLOYMENT_TARGET to set the min iOS version you will require.


### PR DESCRIPTION
Hello,

There's always a problem with iOS simulator using google toolbox -> app crashes with missing categories for NS*** classes.

Problem is missing liker flag -ObjC 