### PR TITLE
Fix Undefined Behavior, left shift of negative value, …

### DIFF
--- a/Foundation/GTMStringEncoding.m
+++ b/Foundation/GTMStringEncoding.m
@@ -196,7 +196,7 @@ GTM_INLINE int lcm(int a, int b) {
   unsigned char *outBuf = (unsigned char *)[outData mutableBytes];
   NSUInteger outPos = 0;
 
-  int buffer = inBuf[inPos++];
+  unsigned int buffer = inBuf[inPos++];
   int bitsLeft = 8;
   while (bitsLeft > 0 || inPos < inLen) {
     if (bitsLeft < shift_) {
@@ -275,7 +275,7 @@ GTM_INLINE int lcm(int a, int b) {
   unsigned char *outBuf = (unsigned char *)[outData mutableBytes];
   NSUInteger outPos = 0;
 
-  int buffer = 0;
+  unsigned int buffer = 0;
   int bitsLeft = 0;
   BOOL expectPad = NO;
   for (NSUInteger i = 0; i < inLen; i++) {


### PR DESCRIPTION
… signed integer overflow.

ubsan output:
.../google_toolbox_for_mac/Foundation/GTMStringEncoding.m:204:16: runtime error: left shift of 10368305 by 8 places cannot be represented in type 'int'
.../google_toolbox_for_mac/Foundation/GTMStringEncoding.m:312:16: runtime error: left shift of 42406098 by 6 places cannot be represented in type 'int'

TESTED=Earth iOS --featires=ubsan