### PR TITLE
Fix up some broken tests.

### DIFF
--- a/Foundation/GTMSQLiteTest.m
+++ b/Foundation/GTMSQLiteTest.m
@@ -629,9 +629,6 @@ static void TestUpperLower16Impl(sqlite3_context *context,
 
   XCTAssertEqual(err, [db lastErrorCode],
                  @"lastErrorCode API did not match what last API returned!");
-  // Calling lastErrorCode resets API error, so the next string will not indicate any error
-  XCTAssertEqualStrings(@"unknown error", [db lastErrorString],
-                        @"lastErrorString API did not match expected string!");
 
   oneRow = [statement resultStringAtPosition:0];
   XCTAssertEqualStrings(oneRow, @"a2", @"a did not come second!");

--- a/Foundation/GTMStackTraceTest.m
+++ b/Foundation/GTMStackTraceTest.m
@@ -38,8 +38,8 @@
 
   XCTAssertGreaterThan([stacklines count], (NSUInteger)3,
                        @"stack trace must have > 3 lines");
-  XCTAssertLessThan([stacklines count], (NSUInteger)37,
-                    @"stack trace must have < 37 lines");
+  XCTAssertLessThan([stacklines count], (NSUInteger)100,
+                    @"stack trace must have < 100 lines");
 
   NSString *firstFrame = [stacklines objectAtIndex:0];
   NSRange range = [firstFrame rangeOfString:@"testStackTraceBasic"];
@@ -103,8 +103,8 @@
 
   XCTAssertGreaterThan([stacklines count], (NSUInteger)4,
                        @"stack trace must have > 4 lines\n%@", stacktrace);
-  XCTAssertLessThan([stacklines count], (NSUInteger)41,
-                    @"stack trace must have < 41 lines\n%@", stacktrace);
+  XCTAssertLessThan([stacklines count], (NSUInteger)100,
+                    @"stack trace must have < 100 lines\n%@", stacktrace);
   XCTAssertEqual([stacklines count],
                  [[exception callStackReturnAddresses] count],
                  @"stack trace should have the same number of lines as the "


### PR DESCRIPTION
- Set up stack trace test just so we make sure we don't recurse. Right now it is too tight and breaks on every system release.
- SQLite's behavior is actually undefined in the case of sqlite3_errcode, so don't depend on it in a test.