### PR TITLE
Fixes up a race condition in GTMNSThread+Blocks

### DIFF
--- a/Foundation/GTMNSThread+Blocks.h
+++ b/Foundation/GTMNSThread+Blocks.h
@@ -38,7 +38,13 @@
 
 #endif  // NS_BLOCKS_AVAILABLE
 
-// A simple thread that does nothing but handle performBlock and
-// performSelector calls.
+// A simple thread that does nothing but runs a runloop.
+// That means that it can handle performBlock and performSelector calls.
 @interface GTMSimpleWorkerThread : NSThread
+
+// If called from another thread, blocks until worker thread is done.
+// If called from the worker thread it is equivalent to cancel and
+// returns immediately.
+// Note that "stop" will set the isCancelled on the thread.
+- (void)stop;
 @end


### PR DESCRIPTION
There was a race between the thread being finished and
isFinished/isExecuting reporting correctly.
There may have also been a locking issue on older single processor phones.