### PR TITLE
Deprecate runloop spinning functionality for tests.

### DIFF
--- a/UnitTesting/GTMAppKitUnitTestingUtilities.h
+++ b/UnitTesting/GTMAppKitUnitTestingUtilities.h
@@ -71,8 +71,10 @@
 // Return YES if the runloop was stopped because [context shouldStop] returned
 // YES.
 - (BOOL)gtm_runUntilDate:(NSDate *)date
-                 context:(id<GTMUnitTestingRunLoopContext>)context;
+                 context:(id<GTMUnitTestingRunLoopContext>)context
+    NS_DEPRECATED(10.4, 10.8, 1.0, 7.0, "Please move to XCTestExpectations");
 
 // Calls -gtm_runUntilDate:context: with the timeout date set to 60 seconds.
-- (BOOL)gtm_runUpToSixtySecondsWithContext:(id<GTMUnitTestingRunLoopContext>)context;
+- (BOOL)gtm_runUpToSixtySecondsWithContext:(id<GTMUnitTestingRunLoopContext>)context
+    NS_DEPRECATED(10.4, 10.8, 1.0, 7.0, "Please move to XCTestExpectations");
 @end

--- a/UnitTesting/GTMFoundationUnitTestingUtilities.h
+++ b/UnitTesting/GTMFoundationUnitTestingUtilities.h
@@ -89,16 +89,19 @@
 // YES.
 - (BOOL)gtm_runUntilDate:(NSDate *)date
                     mode:(NSString *)mode
-                 context:(id<GTMUnitTestingRunLoopContext>)context;
+                 context:(id<GTMUnitTestingRunLoopContext>)context
+    NS_DEPRECATED(10.4, 10.8, 1.0, 7.0, "Please move to XCTestExpectations");
 
 // Calls -gtm_runUntilDate:mode:context: with mode set to NSDefaultRunLoopMode.
 - (BOOL)gtm_runUntilDate:(NSDate *)date
-                 context:(id<GTMUnitTestingRunLoopContext>)context;
+                 context:(id<GTMUnitTestingRunLoopContext>)context
+    NS_DEPRECATED(10.4, 10.8, 1.0, 7.0, "Please move to XCTestExpectations");
 
 // Calls -gtm_runUntilDate:mode:context: with mode set to NSDefaultRunLoopMode,
 // and the timeout date set to |seconds| seconds.
 - (BOOL)gtm_runUpToNSeconds:(NSTimeInterval)seconds
-                    context:(id<GTMUnitTestingRunLoopContext>)context;
+                    context:(id<GTMUnitTestingRunLoopContext>)context
+    NS_DEPRECATED(10.4, 10.8, 1.0, 7.0, "Please move to XCTestExpectations");
 
 // Calls -gtm_runUntilDate:mode:context: with mode set to NSDefaultRunLoopMode,
 // and the timeout date set to 60 seconds.
@@ -106,6 +109,7 @@
 // but may be a bit long for standard unit tests, and could cause a long unit
 // testing run if you have multiple failures.
 // Calling -[gtm_runUpToNSeconds:context:] is preferred.
-- (BOOL)gtm_runUpToSixtySecondsWithContext:(id<GTMUnitTestingRunLoopContext>)context;
+- (BOOL)gtm_runUpToSixtySecondsWithContext:(id<GTMUnitTestingRunLoopContext>)context
+    NS_DEPRECATED(10.4, 10.8, 1.0, 7.0, "Please move to XCTestExpectations");
 
 @end


### PR DESCRIPTION
It should all be replaced with XCTestExpectations.