### PR TITLE
Add deprecation warnings on URLArgument categories.

### DIFF
--- a/Foundation/GTMNSDictionary+URLArguments.h
+++ b/Foundation/GTMNSDictionary+URLArguments.h
@@ -29,12 +29,12 @@
 /// NOTE: Apps targeting iOS 8 or OS X 10.10 and later should use
 ///       NSURLComponents and NSURLQueryItem to create URLs with
 ///       query arguments instead of using these category methods.
-+ (NSDictionary *)gtm_dictionaryWithHttpArgumentsString:(NSString *)argString;
++ (NSDictionary *)gtm_dictionaryWithHttpArgumentsString:(NSString *)argString NS_DEPRECATED(10_0, 10_10, 2_0, 8_0, "Use NSURLComponents and NSURLQueryItem.");
 
 /// Gets a string representation of the dictionary in the form
 /// key1=value1&key2=value2&...&keyN=valueN, suitable for use as either
 /// URL arguments (after a '?') or POST body. Keys and values will be escaped
 /// automatically, so should be unescaped in the dictionary.
-- (NSString *)gtm_httpArgumentsString;
+- (NSString *)gtm_httpArgumentsString NS_DEPRECATED(10_0, 10_10, 2_0, 8_0, "Use NSURLComponents and NSURLQueryItem.");
 
 @end

--- a/Foundation/GTMNSDictionary+URLArguments.m
+++ b/Foundation/GTMNSDictionary+URLArguments.m
@@ -26,6 +26,9 @@
 __attribute__((visibility("default")))
     char GTMNSDictionaryURLArgumentsExportToSuppressLibToolWarning = 0;
 
+#pragma clang diagnostic push
+// Ignore all of the deprecation warnings for GTMNSString+URLArguments
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 
 @implementation NSDictionary (GTMNSDictionaryURLArgumentsAdditions)
 
@@ -75,3 +78,5 @@ GTM_METHOD_CHECK(NSString, gtm_stringByUnescapingFromURLArgument);
 }
 
 @end
+
+#pragma clang diagnostic pop

--- a/Foundation/GTMNSDictionary+URLArgumentsTest.m
+++ b/Foundation/GTMNSDictionary+URLArgumentsTest.m
@@ -20,6 +20,10 @@
 #import "GTMNSDictionary+URLArguments.h"
 #import "GTMDefines.h"
 
+#pragma clang diagnostic push
+// Ignore all of the deprecation warnings for GTMNSDictionary+URLArguments
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+
 @interface GTMNSDictionary_URLArgumentsTest : GTMTestCase
 @end
 
@@ -85,3 +89,5 @@
 }
 
 @end
+
+#pragma clang diagnostic pop

--- a/Foundation/GTMNSString+URLArguments.h
+++ b/Foundation/GTMNSString+URLArguments.h
@@ -34,12 +34,12 @@
 /// NOTE: Apps targeting iOS 8 or OS X 10.10 and later should use
 ///       NSURLComponents and NSURLQueryItem to create properly-escaped
 ///       URLs instead of using these category methods.
-- (NSString*)gtm_stringByEscapingForURLArgument;
+- (NSString*)gtm_stringByEscapingForURLArgument NS_DEPRECATED(10_0, 10_10, 2_0, 8_0, "Use NSURLComponents.");
 
 /// Returns the unescaped version of a URL argument
 ///
 /// This has the same behavior as stringByReplacingPercentEscapesUsingEncoding:,
 /// except that it will also convert '+' to space.
-- (NSString*)gtm_stringByUnescapingFromURLArgument;
+- (NSString*)gtm_stringByUnescapingFromURLArgument NS_DEPRECATED(10_0, 10_10, 2_0, 8_0, "Use NSURLComponents.");
 
 @end

--- a/Foundation/GTMNSString+URLArgumentsTest.m
+++ b/Foundation/GTMNSString+URLArgumentsTest.m
@@ -19,6 +19,10 @@
 #import "GTMSenTestCase.h"
 #import "GTMNSString+URLArguments.h"
 
+#pragma clang diagnostic push
+// Ignore all of the deprecation warnings for GTMNSString+URLArguments
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+
 @interface GTMNSString_URLArgumentsTest : GTMTestCase
 @end
 
@@ -92,3 +96,5 @@
 }
 
 @end
+
+#pragma clang diagnostic pop


### PR DESCRIPTION
The URLArgument categories should be replaced with usages of NSURLComponents and NSURLItems.