### PR TITLE
Fix up timeout for test.

### DIFF
--- a/Foundation/GTMNSThread+BlocksTest.m
+++ b/Foundation/GTMNSThread+BlocksTest.m
@@ -21,7 +21,7 @@
 #import "GTMSenTestCase.h"
 #import "GTMNSThread+Blocks.h"
 
-static const NSTimeInterval kTestTimeout = 5;
+static const NSTimeInterval kTestTimeout = 10;
 static const int kThreadMethodCounter = 5;
 static const int kThreadMethoduSleep = 10000;
 


### PR DESCRIPTION
The changes here had a test looping 5 times with a 1 second wait trying to finish
in a 5 second window. That's a little too close for flakiness. Increased time out to
10 seconds.