### PR TITLE
Fix up race in testPThreadName.

### DIFF
--- a/Foundation/GTMNSThread+BlocksTest.m
+++ b/Foundation/GTMNSThread+BlocksTest.m
@@ -316,7 +316,7 @@ static const int kThreadMethoduSleep = 10000;
 - (void)testPThreadName {
   NSString *testName = @"InigoMontoya";
   [workerThread_ setName:testName];
-  [workerThread_ gtm_performWaitingUntilDone:NO block:^{
+  [workerThread_ gtm_performWaitingUntilDone:YES block:^{
     XCTAssertEqualObjects([workerThread_ name], testName);
     char threadName[100];
     pthread_getname_np(pthread_self(), threadName, 100);


### PR DESCRIPTION
The block must execute before the test completes.