### PR TITLE
Reorder testing of selectors.

### DIFF
--- a/Foundation/GTMLightweightProxy.m
+++ b/Foundation/GTMLightweightProxy.m
@@ -93,11 +93,10 @@
 // Checks the represented object's selectors to allow clients of the proxy to
 // do respondsToSelector: tests.
 - (BOOL)respondsToSelector:(SEL)selector {
-  if ([super respondsToSelector:selector] ||
-      selector == @selector(initWithRepresentedObject:) ||
+  if (selector == @selector(initWithRepresentedObject:) ||
       selector == @selector(representedObject) ||
-      selector == @selector(setRepresentedObject:))
-  {
+      selector == @selector(setRepresentedObject:) ||
+      [super respondsToSelector:selector]) {
     return YES;
   }
 


### PR DESCRIPTION
Pick off the selector natively handled first. NSProxy's base (on my
current OS atleast) will attempt to forward things, and the fact
that the LightWeight proxy then eats the forward where there is no
target objc seems to confuse things.

This all makes the unittests fail when run in release mode, so it
just generally seems safer to reorder this.

The footnote, is NSProxy really defines a class method for this, but
since LightweightProxy doesn't have a fixed class to check with, it
can't really provide that method.