### PR TITLE
Version bump for a release.

### DIFF
--- a/GoogleToolboxForMac.podspec
+++ b/GoogleToolboxForMac.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'GoogleToolboxForMac'
-  s.version          = '2.1.4'
+  s.version          = '2.2.0'
   s.author           = 'Google Inc.'
   s.license          = { :type => 'Apache', :file => 'LICENSE' }
   s.homepage         = 'https://github.com/google/google-toolbox-for-mac'


### PR DESCRIPTION
Looking at what has changed since the last release:
  https://github.com/google/google-toolbox-for-mac/compare/v2.1.4...master

There are two small fixes, but the rest is removing a few unused things and
the majority is marking things as deprecated that the System Frameworks now
provide. So bumping the minor version so folks can control when they adopt
this if they so wish.