### PR TITLE
GTMLocalizer: use NSAccessibility on 10.10+ deployment targets

### DIFF
--- a/AppKit/GTMUILocalizer.m
+++ b/AppKit/GTMUILocalizer.m
@@ -407,6 +407,17 @@
 }
 
 - (void)localizeAccessibility:(id)object {
+#if defined(MAC_OS_X_VERSION_10_10) && \
+    MAC_OS_X_VERSION_MIN_REQUIRED >= MAC_OS_X_VERSION_10_10
+  id<NSAccessibility> accessible = object;
+  if ([accessible conformsToProtocol:@protocol(NSAccessibility)]) {
+    NSString* help = [accessible accessibilityHelp];
+    NSString* localizedHelp = [self localizedStringForString:help];
+    if (localizedHelp) {
+      [accessible setAccessibilityHelp:localizedHelp];
+    }
+  }
+#else
   NSArray *supportedAttrs = [object accessibilityAttributeNames];
   if ([supportedAttrs containsObject:NSAccessibilityHelpAttribute]) {
     NSString *accessibilityHelp
@@ -420,6 +431,7 @@
       }
     }
   }
+#endif
 
   // We cannot do the same thing with NSAccessibilityDescriptionAttribute; see
   // the links in the header file for more details.


### PR DESCRIPTION
This change makes GTMLocalizer use NSAccessibility when building for 10.10+
deployment targets.

I tested this change by:
1) Hacking the GTM Xcode project to build with a 10.10 deployment target, and
   ignoring the other deprecated API uses;
2) Patching this GTM into the chromium tree (which does target 10.10) and
   ensuring that it still builds