### PR TITLE
Fix GTMGoogleTestRunner triggering "NULL cString" exception in NSString.

### DIFF
--- a/UnitTesting/GTMGoogleTestRunner.mm
+++ b/UnitTesting/GTMGoogleTestRunner.mm
@@ -86,7 +86,8 @@ class GoogleTestPrinter : public EmptyTestEventListener {
 
   virtual void OnTestPartResult(const TestPartResult &test_part_result) {
     if (!test_part_result.passed()) {
-      NSString *file = @(test_part_result.file_name());
+      const char *file_name = test_part_result.file_name();
+      NSString *file = @(file_name ? file_name : "<file name unavailable>");
       int line = test_part_result.line_number();
       NSString *summary = @(test_part_result.summary());
 


### PR DESCRIPTION
In case `file_name()` happens to return null, the attempt to report a failure will end up crashing during setup, with a non-informative message like:
```
<unknown>:0: error: -[GTMGoogleTestRunner CleanupTest::DocumentSnapshotIsBlankAfterCleanup]
failed: caught "NSInvalidArgumentException", "*** +[NSString stringWithUTF8String:]: NULL cString"
```

Note: this PR doesn't address the root problem that leads to a null filename, but makes it more apparent.