### PR TITLE
Fix failure due to adding the same method twice

### DIFF
--- a/UnitTesting/GTMGoogleTestRunner.mm
+++ b/UnitTesting/GTMGoogleTestRunner.mm
@@ -175,7 +175,10 @@ NSString *SelectorNameFromGTestName(NSString *testName) {
   Method method = class_getInstanceMethod(cls, @selector(runGoogleTest));
   IMP implementation = method_getImplementation(method);
   const char *encoding = method_getTypeEncoding(method);
-  if (!class_addMethod(cls, selector, implementation, encoding)) {
+  // We may be called more than once for the same testName. Check before adding new method to avoid
+  // failure from adding multiple methods with the same name.
+  if (!class_getInstanceMethod(cls, selector) &&
+      !class_addMethod(cls, selector, implementation, encoding)) {
     // If we can't add a method, we should blow up here.
     [NSException raise:NSInternalInconsistencyException
                 format:@"Unable to add %@ to %@.", testName, cls];


### PR DESCRIPTION
It's possible that XCTestCase defaultTestSuite method is invoked more than once. Currently it has the side-effect of adding new methods to the class but doesn't check if they already exist. This change adds a check to only add new methods if they aren't implemented by the class or its superclass.