### PR TITLE
GTMStringEncoding: Mark deprecated methods to fix parameters in Swift.

### DIFF
--- a/Foundation/GTMStringEncoding.h
+++ b/Foundation/GTMStringEncoding.h
@@ -78,15 +78,19 @@
 - (void)setPaddingChar:(char)c;
 
 // Encode a raw binary buffer to a 7-bit ASCII string.
-- (NSString *)encode:(NSData *)data __attribute__((deprecated("Use encode:error:")));
-- (NSString *)encodeString:(NSString *)string __attribute__((deprecated("Use encodeString:error:")));
+- (NSString *)encode:(NSData *)data __attribute__((deprecated("Use encode:error:")))
+    NS_SWIFT_UNAVAILABLE("Use encode:error: mapped to encode(_ data:) throws");
+- (NSString *)encodeString:(NSString *)string __attribute__((deprecated("Use encodeString:error:")))
+    NS_SWIFT_UNAVAILABLE("Use encode:error: mapped to encode(_ string:) throws");
 
 - (NSString *)encode:(NSData *)data error:(NSError **)error;
 - (NSString *)encodeString:(NSString *)string error:(NSError **)error;
 
 // Decode a 7-bit ASCII string to a raw binary buffer.
-- (NSData *)decode:(NSString *)string __attribute__((deprecated("Use decode:error:")));
-- (NSString *)stringByDecoding:(NSString *)string __attribute__((deprecated("Use stringByDecoding:error:")));
+- (NSData *)decode:(NSString *)string __attribute__((deprecated("Use decode:error:")))
+    NS_SWIFT_UNAVAILABLE("Use decode:error: mapped to decode(_ string:) throws");
+- (NSString *)stringByDecoding:(NSString *)string __attribute__((deprecated("Use stringByDecoding:error:")))
+    NS_SWIFT_UNAVAILABLE("Use stringByDecoding:error: mapped to string(byDecoding string:) throws");
 
 - (NSData *)decode:(NSString *)string error:(NSError **)error;
 - (NSString *)stringByDecoding:(NSString *)string error:(NSError **)error;


### PR DESCRIPTION
Fixes the auto-generated interface methods for the desired methods. The deprecated methods were causing conflicts in the generated interface of the newer methods that would add a zero-length tuple parameter.

Example of fix for `encode:error:`

Interface Before:
```
open func encode(_ data: Data!, error: ()) throws -> String
```
Calling Code Before:
```
do {
  try encodedString = encoder.encode(self, error: ())
} catch let error as NSError {
  print("Error: \(error.domain)")
}
```

Interface After:
```
open func encode(_ data: Data!) throws -> String
```
Calling Code After:
```
do {
  try encodedString = encoder.encode(self)
} catch let error as NSError {
  print("Error: \(error.domain)")
}
```


Closes google/google-toolbox-for-mac#248