### PR TITLE
Remove obsoleted nonsense symbols for suppressing libtool warnings

### DIFF
--- a/Foundation/GTMNSDictionary+URLArguments.m
+++ b/Foundation/GTMNSDictionary+URLArguments.m
@@ -22,10 +22,6 @@
 #import "GTMDefines.h"
 
 
-// Export a nonsense symbol to suppress a libtool warning when this is linked alone in a static lib.
-__attribute__((visibility("default")))
-    char GTMNSDictionaryURLArgumentsExportToSuppressLibToolWarning = 0;
-
 #pragma clang diagnostic push
 // Ignore all of the deprecation warnings for GTMNSString+URLArguments
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"

--- a/Foundation/GTMNSFileHandle+UniqueName.m
+++ b/Foundation/GTMNSFileHandle+UniqueName.m
@@ -20,10 +20,6 @@
 
 #include <unistd.h>
 
-// Export a nonsense symbol to suppress a libtool warning when this is linked alone in a static lib.
-__attribute__((visibility("default")))
-    char GTMFileHandleUniqueNameExportToSuppressLibToolWarning = 0;
-
 
 @implementation NSFileHandle (GTMFileHandleUniqueNameAdditions)
 

--- a/Foundation/GTMNSScanner+JSON.m
+++ b/Foundation/GTMNSScanner+JSON.m
@@ -19,11 +19,6 @@
 #import "GTMDefines.h"
 #import "GTMNSScanner+JSON.h"
 
-// Export a nonsense symbol to suppress a libtool warning when this is linked
-// alone in a static lib.
-__attribute__((visibility("default")))
-    char NSScanner_GTMNSScannerJSONAdditionsExportToSuppressLibToolWarning = 0;
-
 @implementation NSScanner (GTMNSScannerJSONAdditions)
 
 - (BOOL)gtm_scanJSONString:(NSString **)jsonString

--- a/Foundation/GTMNSString+HTML.m
+++ b/Foundation/GTMNSString+HTML.m
@@ -20,11 +20,6 @@
 #import "GTMDefines.h"
 #import "GTMNSString+HTML.h"
 
-// Export a nonsense symbol to suppress a libtool warning when this is linked
-// alone in a static lib.
-__attribute__((visibility("default")))
-    char GTMNSString_HTMLExportToSuppressLibToolWarning = 0;
-
 typedef struct {
   NSString *escapeSequence;
   unichar uchar;

--- a/Foundation/GTMNSString+XML.m
+++ b/Foundation/GTMNSString+XML.m
@@ -19,10 +19,6 @@
 #import "GTMDefines.h"
 #import "GTMNSString+XML.h"
 
-// Export a nonsense symbol to suppress a libtool warning when this is linked alone in a static lib.
-__attribute__((visibility("default")))
-    char NSString_GTMNSStringXMLAdditionsExportToSuppressLibToolWarning = 0;
-
 enum {
   kGTMXMLCharModeEncodeQUOT  = 0,
   kGTMXMLCharModeEncodeAMP   = 1,

--- a/iPhone/GTMUIFont+LineHeight.m
+++ b/iPhone/GTMUIFont+LineHeight.m
@@ -20,11 +20,6 @@
 
 #import <Availability.h>
 
-// Export a nonsense symbol to suppress a libtool warning when this is linked
-// alone in a static lib.
-__attribute__((visibility("default")))
-    char GTMUIFont_LineHeightExportToSuppressLibToolWarning = 0;
-
 @implementation UIFont (GTMLineHeight)
 - (CGFloat)gtm_lineHeight {
 #if __IPHONE_OS_VERSION_MIN_REQUIRED < __IPHONE_7_0


### PR DESCRIPTION
This removes all the nonsense symbols for suppressing libtool warnings that we no longer need.