### PR TITLE
Avoid nullability compiler/clang-tidy warnings in _GTMDevAssert.

### DIFF
--- a/GTMDefines.h
+++ b/GTMDefines.h
@@ -130,11 +130,16 @@
 #if !defined(NS_BLOCK_ASSERTIONS)
   #define _GTMDevAssert(condition, ...)                                       \
     do {                                                                      \
-      if (!(condition)) {                                                     \
+      if (__builtin_expect(!(condition), 0)) {                                \
+        NSString *__assert_func_name__ =                                      \
+            [NSString stringWithUTF8String:__PRETTY_FUNCTION__];              \
+        __assert_func_name__ = __assert_func_name__ ?: @"<Unknown Function>"; \
+        NSString *__assert_file_name__ =                                      \
+            [NSString stringWithUTF8String:__FILE__];                         \
+        __assert_file_name__ = __assert_file_name__ ?: @"<Unknown File>";     \
         [[NSAssertionHandler currentHandler]                                  \
-            handleFailureInFunction:(NSString *)                              \
-                                        [NSString stringWithUTF8String:__PRETTY_FUNCTION__] \
-                               file:(NSString *)[NSString stringWithUTF8String:__FILE__]  \
+            handleFailureInFunction:__assert_func_name__                      \
+                               file:__assert_file_name__                      \
                          lineNumber:__LINE__                                  \
                         description:__VA_ARGS__];                             \
       }                                                                       \


### PR DESCRIPTION
The string parameters in NSAssertionHandler's -handleFailureInFunction:… method are declared nonnull, but converting __PRETTY_FUNCTION__ and __FILE__ to NSString (via +[NSString stringWithUTF8String:] returns nullable, leading to warnings.

I don't know of any reason __PRETTY_FUNCTION__ or __FILE__ would ever fail to convert to UTF-8, but this deals with the warnings by explicitly handling the nil return case from stringWithUTF8String: by providing a static string.

Also adds a __builtin_expect() around the condition, as the intention is that the condition should never be true.