### PR TITLE
userdata structures need to exist for lifetime of hooks.

### DIFF
--- a/Foundation/GTMSQLite.m
+++ b/Foundation/GTMSQLite.m
@@ -231,7 +231,7 @@ static CFLocaleRef gCurrentLocale = NULL;
   int rc = SQLITE_OK;
   // Install our custom functions for improved text handling
   // UPPER/LOWER
-  const struct {
+  static const struct {
     const char           *sqlName;
     UpperLowerUserArgs   userArgs;
     void                 *function;
@@ -263,7 +263,7 @@ static CFLocaleRef gCurrentLocale = NULL;
   }
 
   // Fixed collation sequences
-  const struct {
+  static const struct {
     const char           *sqlName;
     CollateUserArgs      userArgs;
     void                 *function;
@@ -288,7 +288,7 @@ static CFLocaleRef gCurrentLocale = NULL;
   }
 
   // Install handler for dynamic collation sequences
-  const struct {
+  static const struct {
     const char          *sqlName;
     int                 numArgs;
     int                 textRep;
@@ -335,7 +335,7 @@ static CFLocaleRef gCurrentLocale = NULL;
   }
 
   // Start GLOB just non-literal but case-sensitive (same as SQLite defaults)
-  const struct {
+  static const struct {
     const char          *sqlName;
     int                 textRep;
     void                *function;

--- a/Foundation/GTMSQLiteTest.m
+++ b/Foundation/GTMSQLiteTest.m
@@ -425,7 +425,7 @@ static void TestUpperLower16Impl(sqlite3_context *context,
                                                   errorCode:&err]
       autorelease];
 
-  const struct {
+  static const struct {
     const char           *sqlName;
     UpperLowerUserArgs   userArgs;
     void                 *function;


### PR DESCRIPTION
Apparently earlier compilers took our `const structs` and put them into const
data for us so their lifetime was effectively equivalent to `static`. Some
change/optimization in 11.4.1 has moved to that not being the case. Explicitly
make the data structures `static`.
