### PR TITLE
Add a missing void *-to-char * cast

### DIFF
--- a/Foundation/GTMRegex.m
+++ b/Foundation/GTMRegex.m
@@ -659,7 +659,7 @@ static NSString *const kReplacementPattern =
     [self class], self,
     regex_,
     (allSegments_ ? "YES" : "NO"),
-    (int)(MIN(len, 20)), [utf8StrBuf_ bytes],
+    (int)(MIN(len, 20)), (const char *)[utf8StrBuf_ bytes],
     (len > 20 ? "..." : "")];
 }
 


### PR DESCRIPTION
`NSData-bytes` returns a `const void *`. Cast it to a `const char *` before trying to use with a `%s` format specifier.