### PR TITLE
Fix for undefined symbols errors in GTMRegex.h

### DIFF
--- a/Foundation/GTMRegex.h
+++ b/Foundation/GTMRegex.h
@@ -70,15 +70,15 @@ typedef NSUInteger GTMRegexOptions;
 
 #pragma clang diagnostic pop
 
-_EXTERN NSString* kGTMRegexErrorDomain _INITIALIZE_AS(@"com.google.mactoolbox.RegexDomain");
+GTM_EXTERN NSString* kGTMRegexErrorDomain;
 
 enum {
   kGTMRegexPatternParseFailedError = -100
 };
 
 // Keys for the userInfo from a kGTMRegexErrorDomain/kGTMRegexPatternParseFailedError error
-_EXTERN NSString* kGTMRegexPatternErrorPattern _INITIALIZE_AS(@"pattern");
-_EXTERN NSString* kGTMRegexPatternErrorErrorString _INITIALIZE_AS(@"patternError");
+GTM_EXTERN NSString* kGTMRegexPatternErrorPattern;
+GTM_EXTERN NSString* kGTMRegexPatternErrorErrorString;
 
 /// Class for doing Extended Regex operations w/ libregex (see re_format(7)).
 //

--- a/Foundation/GTMRegex.h
+++ b/Foundation/GTMRegex.h
@@ -58,16 +58,6 @@ typedef NSUInteger GTMRegexOptions;
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wreserved-id-macro"
 
-#undef _EXTERN
-#undef _INITIALIZE_AS
-#if GTMREGEX_DEFINE_GLOBALS
-#define _EXTERN
-#define _INITIALIZE_AS(x) =x
-#else
-#define _EXTERN GTM_EXTERN
-#define _INITIALIZE_AS(x)
-#endif
-
 #pragma clang diagnostic pop
 
 GTM_EXTERN NSString* kGTMRegexErrorDomain;

--- a/Foundation/GTMRegex.m
+++ b/Foundation/GTMRegex.m
@@ -16,7 +16,6 @@
 //  the License.
 //
 
-#define GTMREGEX_DEFINE_GLOBALS 1
 #import "GTMRegex.h"
 #import "GTMDefines.h"
 

--- a/Foundation/GTMRegex.m
+++ b/Foundation/GTMRegex.m
@@ -25,6 +25,10 @@
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
 #pragma clang diagnostic ignored "-Wdeprecated-implementations"
 
+NSString *const kGTMRegexErrorDomain = @"com.google.mactoolbox.RegexDomain";
+NSString *const kGTMRegexPatternErrorPattern = @"pattern";
+NSString *const kGTMRegexPatternErrorErrorString = @"patternError";
+
 // This is the pattern to use for walking replacement text when doing
 // substitutions.
 //


### PR DESCRIPTION
Fixes an issue where in certain compilation situations you could get
undefined symbols errors out of GTMRegex.h. The solution is to define
these string constants in the GTMRegex.m file

```
undef: _kGTMRegexPatternErrorErrorString
undef: _kGTMRegexPatternErrorPattern
undef: _kGTMRegexErrorDomain
Undefined symbols for architecture x86_64:
  "_kGTMRegexPatternErrorErrorString", referenced from:
      -[GTMRegex initWithPattern:options:withError:] in libRegex.a(GTMRegex.o)
  "_kGTMRegexPatternErrorPattern", referenced from:
      -[GTMRegex initWithPattern:options:withError:] in libRegex.a(GTMRegex.o)
  "_kGTMRegexErrorDomain", referenced from:
      -[GTMRegex initWithPattern:options:withError:] in libRegex.a(GTMRegex.o)
ld: symbol(s) not found for architecture x86_64
```