### PR TITLE
Use atomic property to store cached `verboseLoggingEnabled` value.

### DIFF
--- a/Foundation/GTMLogger.h
+++ b/Foundation/GTMLogger.h
@@ -475,7 +475,6 @@ typedef enum {
 // never filtered.
 @interface GTMLogLevelFilter : NSObject <GTMLogFilter> {
  @private
-  BOOL verboseLoggingEnabled_;
   NSUserDefaults *userDefaults_;
 }
 @end  // GTMLogLevelFilter

--- a/Foundation/GTMLogger.m
+++ b/Foundation/GTMLogger.m
@@ -517,12 +517,18 @@ static BOOL IsVerboseLoggingEnabled(NSUserDefaults *userDefaults) {
 }
 // COV_NF_END
 
+@interface GTMLogLevelFilter ()
+
+@property (atomic) BOOL verboseLoggingEnabled;
+
+@end
+
 @implementation GTMLogLevelFilter
 
 - (id)init {
   self = [super init];
   if (self) {
-    verboseLoggingEnabled_ = IsVerboseLoggingEnabled(userDefaults_);
+    self.verboseLoggingEnabled = IsVerboseLoggingEnabled(userDefaults_);
   }
 
   return self;
@@ -554,7 +560,7 @@ static BOOL IsVerboseLoggingEnabled(NSUserDefaults *userDefaults) {
       allow = NO;
       break;
     case kGTMLoggerLevelInfo:
-      allow = verboseLoggingEnabled_;
+      allow = self.verboseLoggingEnabled;
       break;
     case kGTMLoggerLevelError:
       allow = YES;
@@ -627,7 +633,7 @@ static BOOL IsVerboseLoggingEnabled(NSUserDefaults *userDefaults) {
                        context:(void *)context
 {
   if([keyPath isEqual:kVerboseLoggingKey]) {
-    verboseLoggingEnabled_ = IsVerboseLoggingEnabled(userDefaults_);
+    self.verboseLoggingEnabled = IsVerboseLoggingEnabled(userDefaults_);
   }
 }
 


### PR DESCRIPTION
The cached value can be updated on any thread because any thread can trigger the KVO notification. Therefore, reading/writing the value needs to be atomic.