### PR TITLE
Fix up isEqual so the parameter is `id` as declared in NSObject.

### DIFF
--- a/Foundation/GTMURLBuilder.h
+++ b/Foundation/GTMURLBuilder.h
@@ -68,6 +68,6 @@ __deprecated_msg("GTMURLBuilder is obsolete; update your app to use NSURLCompone
 
 // Case-sensitive comparison of the URL. Also protocol and host are compared
 // as case-sensitive strings. The order of URL parameters is ignored.
-- (BOOL)isEqual:(GTMURLBuilder *)URLBuilder;
+- (BOOL)isEqual:(id)URLBuilder;
 
 @end

--- a/Foundation/GTMURLBuilder.m
+++ b/Foundation/GTMURLBuilder.m
@@ -119,10 +119,12 @@
   return [[self URL] absoluteString];
 }
 
-- (BOOL)isEqual:(GTMURLBuilder *)URLBuilder {
-  if (!URLBuilder) {
+- (BOOL)isEqual:(id)object {
+  if (![object isKindOfClass:[GTMURLBuilder class]]) {
     return NO;
   }
+
+  GTMURLBuilder *URLBuilder = (GTMURLBuilder *)object;
 
   if (!([[self baseURLString] isEqualToString:[URLBuilder baseURLString]])) {
     return NO;


### PR DESCRIPTION
This allows compilation with `-Woverriding-method-mismatch`.