### PR TITLE
Modernize constants

### DIFF
--- a/AppKit/GTMCarbonEvent.m
+++ b/AppKit/GTMCarbonEvent.m
@@ -321,21 +321,31 @@ GTM_PARAM_TEMPLATE_DEFN(EventHotKeyID)
 
 UInt32 GTMCocoaToCarbonKeyModifiers(NSUInteger inCocoaModifiers) {
   UInt32 carbModifiers = 0;
-  if (inCocoaModifiers & NSAlphaShiftKeyMask) carbModifiers |= alphaLock;
-  if (inCocoaModifiers & NSShiftKeyMask) carbModifiers |= shiftKey;
-  if (inCocoaModifiers & NSControlKeyMask) carbModifiers |= controlKey;
-  if (inCocoaModifiers & NSAlternateKeyMask) carbModifiers |= optionKey;
-  if (inCocoaModifiers & NSCommandKeyMask) carbModifiers |= cmdKey;
+  if (inCocoaModifiers & NSEventModifierFlagCapsLock)
+    carbModifiers |= alphaLock;
+  if (inCocoaModifiers & NSEventModifierFlagShift)
+    carbModifiers |= shiftKey;
+  if (inCocoaModifiers & NSEventModifierFlagControl)
+    carbModifiers |= controlKey;
+  if (inCocoaModifiers & NSEventModifierFlagOption)
+    carbModifiers |= optionKey;
+  if (inCocoaModifiers & NSEventModifierFlagCommand)
+    carbModifiers |= cmdKey;
   return carbModifiers;
 }
 
 NSUInteger GTMCarbonToCocoaKeyModifiers(UInt32 inCarbonModifiers) {
   NSUInteger nsModifiers = 0;
-  if (inCarbonModifiers & alphaLock) nsModifiers |= NSAlphaShiftKeyMask;
-  if (inCarbonModifiers & shiftKey) nsModifiers |= NSShiftKeyMask;
-  if (inCarbonModifiers & controlKey) nsModifiers |= NSControlKeyMask;
-  if (inCarbonModifiers & optionKey) nsModifiers |= NSAlternateKeyMask;
-  if (inCarbonModifiers & cmdKey) nsModifiers |= NSCommandKeyMask;
+  if (inCarbonModifiers & alphaLock)
+    nsModifiers |= NSEventModifierFlagCapsLock;
+  if (inCarbonModifiers & shiftKey)
+    nsModifiers |= NSEventModifierFlagShift;
+  if (inCarbonModifiers & controlKey)
+    nsModifiers |= NSEventModifierFlagControl;
+  if (inCarbonModifiers & optionKey)
+    nsModifiers |= NSEventModifierFlagOption;
+  if (inCarbonModifiers & cmdKey)
+    nsModifiers |= NSEventModifierFlagCommand;
   return nsModifiers;
 }
 

--- a/AppKit/GTMCarbonEventTest.m
+++ b/AppKit/GTMCarbonEventTest.m
@@ -345,11 +345,11 @@ extern EventTargetRef GetApplicationEventTarget(void);
     NSUInteger cocoaKey_;
     UInt32 carbonKey_;
   } keyMap[] = {
-    { NSAlphaShiftKeyMask, alphaLock},
-    { NSShiftKeyMask, shiftKey},
-    { NSControlKeyMask, controlKey},
-    { NSAlternateKeyMask, optionKey},
-    { NSCommandKeyMask, cmdKey},
+      {NSEventModifierFlagCapsLock, alphaLock},
+      {NSEventModifierFlagShift, shiftKey},
+      {NSEventModifierFlagControl, controlKey},
+      {NSEventModifierFlagOption, optionKey},
+      {NSEventModifierFlagCommand, cmdKey},
   };
   size_t combos = pow(2, sizeof(keyMap) / sizeof(keyMap[0]));
   for (size_t i = 0; i < combos; i++) {

--- a/AppKit/GTMFadeTruncatingTextFieldCell.m
+++ b/AppKit/GTMFadeTruncatingTextFieldCell.m
@@ -50,8 +50,7 @@
 
   if ([self drawsBackground]) {
     [[self backgroundColor] set];
-    NSRectFillUsingOperation(backgroundRect,
-                             NSCompositeSourceOver);
+    NSRectFillUsingOperation(backgroundRect, NSCompositingOperationSourceOver);
   }
 
   [NSGraphicsContext saveGraphicsState];
@@ -174,7 +173,8 @@
   [NSGraphicsContext saveGraphicsState];
   if ([self drawsBackground]) {
     [[self backgroundColor] set];
-    NSRectFillUsingOperation(solidBackgroundPart, NSCompositeSourceOver);
+    NSRectFillUsingOperation(solidBackgroundPart,
+                             NSCompositingOperationSourceOver);
   }
   // We draw the text ourselves because [super drawInteriorWithFrame:inView:]
   // doesn't draw correctly if the cell draws its own background.

--- a/AppKit/GTMUILocalizerAndLayoutTweaker.m
+++ b/AppKit/GTMUILocalizerAndLayoutTweaker.m
@@ -599,8 +599,8 @@ static NSSize SizeToFit(NSView *view, NSPoint offset) {
       NSButton *button = (NSButton *)view;
       // -[NSButton sizeToFit] gives much worse results than IB's Size to Fit
       // option for standard push buttons.
-      if (([button bezelStyle] == NSRoundedBezelStyle) &&
-          ([[button cell] controlSize] == NSRegularControlSize)) {
+      if (([button bezelStyle] == NSBezelStyleRounded) &&
+          ([[button cell] controlSize] == NSControlSizeRegular)) {
         // This is the amount of padding IB adds over a sizeToFit, empirically
         // determined.
         const CGFloat kExtraPaddingAmount = 12.0;
@@ -612,8 +612,8 @@ static NSSize SizeToFit(NSView *view, NSPoint offset) {
         if (NSWidth(newFrame) < kMinButtonWidth) {
           newFrame.size.width = kMinButtonWidth;
         }
-      } else if ([button bezelStyle] == NSTexturedRoundedBezelStyle &&
-                 [[button cell] controlSize] == NSRegularControlSize) {
+      } else if ([button bezelStyle] == NSBezelStyleTexturedRounded &&
+                 [[button cell] controlSize] == NSControlSizeRegular) {
         // The round textured style needs to have a little extra padding,
         // otherwise the baseline of the text sinks by a few pixels.
         const CGFloat kExtraPaddingAmount = 4.0;


### PR DESCRIPTION
When Apple introduced Swift, they renamed all the AppKit Objective-C
constants to have a shared prefix for ease of bridging, and deprecated
all the old names. These new names were introduced in the macOS 10.12
and 10.14 SDKs, but compile down to the same constant values so they
can be deployed all the way back to 10.0.