### PR TITLE
Drop the ScreenSaver check.

### DIFF
--- a/AppKit/GTMCarbonEventTest.m
+++ b/AppKit/GTMCarbonEventTest.m
@@ -269,69 +269,59 @@ static const UInt32 kTestParameterValue = 'bam ';
 }
 
 - (void)testRegisterHotKeyModifiersTargetActionWhenPressed {
+  GTMCarbonEventDispatcherHandler *dispatcher
+    = [GTMCarbonEventDispatcherHandler sharedEventDispatcherHandler];
+  XCTAssertNotNil(dispatcher, @"Unable to acquire singleton");
+  UInt32 keyMods = (NSShiftKeyMask | NSControlKeyMask
+                    | NSAlternateKeyMask | NSCommandKeyMask);
+  XCTAssertNil([dispatcher registerHotKey:0x5
+                                modifiers:keyMods
+                                   target:nil
+                                   action:nil
+                                 userInfo:nil
+                              whenPressed:YES],
+                @"Shouldn't have created hotkey");
+  GTMCarbonHotKey *hotKey = [dispatcher registerHotKey:0x5
+                                             modifiers:keyMods
+                                                target:self
+                                                action:@selector(hitHotKey:)
+                                              userInfo:self
+                                           whenPressed:YES];
+  XCTAssertNotNil(hotKey, @"Unable to create hotkey");
 
-  // This test can't be run if the screen saver is active because the security
-  // agent blocks us from sending events via remote operations
-  if (![GTMAppKitUnitTestingUtilities isScreenSaverActive]) {
-    GTMCarbonEventDispatcherHandler *dispatcher
-      = [GTMCarbonEventDispatcherHandler sharedEventDispatcherHandler];
-    XCTAssertNotNil(dispatcher, @"Unable to acquire singleton");
-    UInt32 keyMods = (NSShiftKeyMask | NSControlKeyMask
-                      | NSAlternateKeyMask | NSCommandKeyMask);
-    XCTAssertNil([dispatcher registerHotKey:0x5
-                                  modifiers:keyMods
-                                     target:nil
-                                     action:nil
-                                   userInfo:nil
-                                whenPressed:YES],
-                  @"Shouldn't have created hotkey");
-    GTMCarbonHotKey *hotKey = [dispatcher registerHotKey:0x5
-                                               modifiers:keyMods
-                                                  target:self
-                                                  action:@selector(hitHotKey:)
-                                                userInfo:self
-                                             whenPressed:YES];
-    XCTAssertNotNil(hotKey, @"Unable to create hotkey");
-
-    // Post the hotkey combo to the event queue. If everything is working
-    // correctly hitHotKey: should get called, and hotKeyHitExpecatation_ will
-    // be set for us. We run the event loop for a set amount of time waiting for
-    // this to happen.
-    hotKeyHitExpectation_ = [self expectationWithDescription:@"hotKey"];
-    [GTMAppKitUnitTestingUtilities postTypeCharacterEvent:'g' modifiers:keyMods];
-    [self waitForExpectationsWithTimeout:60 handler:NULL];
-    [dispatcher unregisterHotKey:hotKey];
-  }
+  // Post the hotkey combo to the event queue. If everything is working
+  // correctly hitHotKey: should get called, and hotKeyHitExpecatation_ will
+  // be set for us. We run the event loop for a set amount of time waiting for
+  // this to happen.
+  hotKeyHitExpectation_ = [self expectationWithDescription:@"hotKey"];
+  [GTMAppKitUnitTestingUtilities postTypeCharacterEvent:'g' modifiers:keyMods];
+  [self waitForExpectationsWithTimeout:60 handler:NULL];
+  [dispatcher unregisterHotKey:hotKey];
 }
 
 - (void)testRegisterHotKeyModifiersTargetActionWhenPressedException {
+  GTMCarbonEventDispatcherHandler *dispatcher
+    = [GTMCarbonEventDispatcherHandler sharedEventDispatcherHandler];
+  XCTAssertNotNil(dispatcher, @"Unable to acquire singleton");
+  UInt32 keyMods = (NSShiftKeyMask | NSControlKeyMask
+                    | NSAlternateKeyMask | NSCommandKeyMask);
+  GTMCarbonHotKey *hotKey
+    = [dispatcher registerHotKey:0x5
+                       modifiers:keyMods
+                          target:self
+                          action:@selector(hitExceptionalHotKey:)
+                        userInfo:self
+                     whenPressed:YES];
+  XCTAssertNotNil(hotKey, @"Unable to create hotkey");
 
-  // This test can't be run if the screen saver is active because the security
-  // agent blocks us from sending events via remote operations
-  if (![GTMAppKitUnitTestingUtilities isScreenSaverActive]) {
-    GTMCarbonEventDispatcherHandler *dispatcher
-      = [GTMCarbonEventDispatcherHandler sharedEventDispatcherHandler];
-    XCTAssertNotNil(dispatcher, @"Unable to acquire singleton");
-    UInt32 keyMods = (NSShiftKeyMask | NSControlKeyMask
-                      | NSAlternateKeyMask | NSCommandKeyMask);
-    GTMCarbonHotKey *hotKey
-      = [dispatcher registerHotKey:0x5
-                         modifiers:keyMods
-                            target:self
-                            action:@selector(hitExceptionalHotKey:)
-                          userInfo:self
-                       whenPressed:YES];
-    XCTAssertNotNil(hotKey, @"Unable to create hotkey");
-
-    // Post the hotkey combo to the event queue. If everything is working
-    // correctly hitHotKey: should get called, and hotKeyHitExpecatation_ will
-    // be set for us. We run the event loop for a set amount of time waiting for
-    // this to happen.
-    hotKeyHitExpectation_ = [self expectationWithDescription:@"hotKey"];
-    [GTMAppKitUnitTestingUtilities postTypeCharacterEvent:'g' modifiers:keyMods];
-    [self waitForExpectationsWithTimeout:60 handler:NULL];
-    [dispatcher unregisterHotKey:hotKey];
-  }
+  // Post the hotkey combo to the event queue. If everything is working
+  // correctly hitHotKey: should get called, and hotKeyHitExpecatation_ will
+  // be set for us. We run the event loop for a set amount of time waiting for
+  // this to happen.
+  hotKeyHitExpectation_ = [self expectationWithDescription:@"hotKey"];
+  [GTMAppKitUnitTestingUtilities postTypeCharacterEvent:'g' modifiers:keyMods];
+  [self waitForExpectationsWithTimeout:60 handler:NULL];
+  [dispatcher unregisterHotKey:hotKey];
 }
 
 - (void)testKeyModifiers {

--- a/UnitTesting/GTMAppKitUnitTestingUtilities.h
+++ b/UnitTesting/GTMAppKitUnitTestingUtilities.h
@@ -23,10 +23,6 @@
 // Collection of utilities for unit testing
 @interface GTMAppKitUnitTestingUtilities : NSObject
 
-// Check if the screen saver is running. Some unit tests don't work when
-// the screen saver is active.
-+ (BOOL)isScreenSaverActive;
-
 // Allows for posting either a keydown or a keyup with all the modifiers being
 // applied. Passing a 'g' with NSKeyDown and NSShiftKeyMask
 // generates two events (a shift key key down and a 'g' key keydown). Make sure

--- a/UnitTesting/GTMAppKitUnitTestingUtilities.m
+++ b/UnitTesting/GTMAppKitUnitTestingUtilities.m
@@ -23,26 +23,6 @@ static CGKeyCode GTMKeyCodeForCharCode(CGCharCode charCode);
 
 @implementation GTMAppKitUnitTestingUtilities
 
-+ (BOOL)isScreenSaverActive {
-  BOOL answer = NO;
-  ProcessSerialNumber psn;
-  if (GetFrontProcess(&psn) == noErr) {
-    CFDictionaryRef cfProcessInfo
-      = ProcessInformationCopyDictionary(&psn,
-                                         kProcessDictionaryIncludeAllInformationMask);
-    NSDictionary *processInfo = GTMCFAutorelease(cfProcessInfo);
-
-    NSString *bundlePath = [processInfo objectForKey:@"BundlePath"];
-    // ScreenSaverEngine is the frontmost app if the screen saver is actually
-    // running Security Agent is the frontmost app if the "enter password"
-    // dialog is showing
-    NSString *bundleName = [bundlePath lastPathComponent];
-    answer = ([bundleName isEqualToString:@"ScreenSaverEngine.app"]
-              || [bundleName isEqualToString:@"SecurityAgent.app"]);
-  }
-  return answer;
-}
-
 // Allows for posting either a keydown or a keyup with all the modifiers being
 // applied. Passing a 'g' with NSKeyDown and NSShiftKeyMask
 // generates two events (a shift key key down and a 'g' key keydown). Make sure
@@ -62,7 +42,6 @@ static CGKeyCode GTMKeyCodeForCharCode(CGCharCode charCode);
 + (void)postKeyEvent:(NSEventType)type
            character:(CGCharCode)keyChar
            modifiers:(UInt32)cocoaModifiers {
-  __Require(![self isScreenSaverActive], CantWorkWithScreenSaver);
   __Require(type == NSKeyDown || type == NSKeyUp, CantDoEvent);
   CGKeyCode code = GTMKeyCodeForCharCode(keyChar);
   __Verify(code != 256);
@@ -73,7 +52,6 @@ static CGKeyCode GTMKeyCodeForCharCode(CGCharCode charCode);
   CFRelease(event);
 CantCreateEvent:
 CantDoEvent:
-CantWorkWithScreenSaver:
   return;
 }
 


### PR DESCRIPTION
Impl was dependent on some APIs deprecated in 10.9, and at this point with all
the OS changes since then, it might not even be detecting things correctly.