### PR TITLE
Drop the helper for python, perl, and bash runners.

### DIFF
--- a/Foundation/GTMScriptRunner.h
+++ b/Foundation/GTMScriptRunner.h
@@ -60,9 +60,6 @@
 // are associated with the specified interpreter.  The default interpreter
 // (returned from +runner is "/bin/sh").
 + (GTMScriptRunner *)runner;
-+ (GTMScriptRunner *)runnerWithBash;
-+ (GTMScriptRunner *)runnerWithPerl;
-+ (GTMScriptRunner *)runnerWithPython;
 
 // Returns an autoreleased GTMScriptRunner instance associated with the specified
 // interpreter, and the given args.  The specified args are the arguments that

--- a/Foundation/GTMScriptRunner.m
+++ b/Foundation/GTMScriptRunner.m
@@ -36,18 +36,6 @@ static BOOL LaunchNSTaskCatchingExceptions(NSTask *task);
   return [[[self alloc] init] autorelease];
 }
 
-+ (GTMScriptRunner *)runnerWithBash {
-  return [self runnerWithInterpreter:@"/bin/bash"];
-}
-
-+ (GTMScriptRunner *)runnerWithPerl {
-  return [self runnerWithInterpreter:@"/usr/bin/perl"];
-}
-
-+ (GTMScriptRunner *)runnerWithPython {
-  return [self runnerWithInterpreter:@"/usr/bin/python"];
-}
-
 + (GTMScriptRunner *)runnerWithInterpreter:(NSString *)interp {
   return [self runnerWithInterpreter:interp withArgs:nil];
 }


### PR DESCRIPTION
With Apple no longer bundling python2, seems better not to generally provide
helpers that might require devtools to be installed.

Bash is also no longer the default shell, and while lots of script would likely
fail without it, seems safer to also just drop that helper too.

Update the tests to use a simpler shell where possible, the one test using
python to validate buffer handling is updated to try and find an installed
python, but it is only a testing dependency, so seems safe for now.