### PR TITLE
Use GTEST_FLAG_SET instead of ::testing::GTEST_FLAG

### DIFF
--- a/UnitTesting/GTMGoogleTestRunner.mm
+++ b/UnitTesting/GTMGoogleTestRunner.mm
@@ -290,7 +290,7 @@ NSString *SelectorNameFromGTestName(NSString *testName) {
 
   // Since there is no way of running a single GoogleTest directly, we use the
   // filter mechanism in GoogleTest to simulate it for us.
-  ::testing::GTEST_FLAG(filter) = [testName_ UTF8String];
+  GTEST_FLAG_SET(filter, [testName_ UTF8String]);
 
   // Intentionally ignore return value of RUN_ALL_TESTS. We will be printing
   // the output appropriately, and there is no reason to mark this test as


### PR DESCRIPTION
GTEST_FLAG_SET is provided for portability of set parameters, as the actual contents may differ. For more information, see:

https://github.com/google/googletest/blob/main/googletest/include/gtest/internal/gtest-port.h#L2206
https://github.com/google/googletest/blob/main/googletest/include/gtest/internal/gtest-port.h#L2249

Note the second implementation matches what's done here, whereas the first is for binaries that include ABSL.