### PR TITLE
Always import CoreGraphics.

### DIFF
--- a/Foundation/GTMGeometryUtils.h
+++ b/Foundation/GTMGeometryUtils.h
@@ -20,10 +20,9 @@
 //
 
 #import <Foundation/Foundation.h>
-#import "GTMDefines.h"
-#if GTM_IPHONE_SDK
 #import <CoreGraphics/CoreGraphics.h>
-#endif //  GTM_IPHONE_SDK
+
+#import "GTMDefines.h"
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
Looks like in some newer Xcodes, Swift modules would prefer is CoreGraphics was imported instead of just Foundation.