### PR TITLE
More nullability annotations.

### DIFF
--- a/Foundation/GTMLoggerRingBufferWriter.h
+++ b/Foundation/GTMLoggerRingBufferWriter.h
@@ -19,6 +19,8 @@
 #import "GTMLogger.h"
 #import "GTMDefines.h"
 
+NS_ASSUME_NONNULL_BEGIN
+
 typedef struct GTMRingBufferPair GTMRingBufferPair;
 
 // GTMLoggerRingBufferWriter is a GTMLogWriter that accumulates logged Info
@@ -62,6 +64,8 @@ typedef struct GTMRingBufferPair GTMRingBufferPair;
 + (instancetype)ringBufferWriterWithCapacity:(NSUInteger)capacity
                                       writer:(id<GTMLogWriter>)loggerWriter;
 
+- (instancetype)init NS_UNAVAILABLE;
+
 // Designated initializer.  If |writer| is nil, then nil is returned.
 // If you just use -init, nil will be returned.
 - (instancetype)initWithCapacity:(NSUInteger)capacity
@@ -95,3 +99,5 @@ typedef struct GTMRingBufferPair GTMRingBufferPair;
 - (void)dumpContents;
 
 @end  // GTMLoggerRingBufferWriter
+
+NS_ASSUME_NONNULL_END

--- a/Foundation/GTMLoggerRingBufferWriter.m
+++ b/Foundation/GTMLoggerRingBufferWriter.m
@@ -83,12 +83,6 @@ typedef void (GTMRingBufferPairCallback)(GTMLoggerRingBufferWriter *rbw,
 
 }  // initWithCapacity
 
-
-- (instancetype)init {
-  return [self initWithCapacity:0 writer:nil];
-}  // init
-
-
 - (void)dealloc {
   [self reset];
 

--- a/Foundation/GTMLoggerRingBufferWriterTest.m
+++ b/Foundation/GTMLoggerRingBufferWriterTest.m
@@ -129,13 +129,11 @@
                                                      writer:countingWriter_];
   XCTAssertNil(writer);
 
+  // Ensure passing nil doesn't crash, even though it shouldn't be done.
+  id passNil = nil;
   writer = [GTMLoggerRingBufferWriter ringBufferWriterWithCapacity:32
-                                                             writer:nil];
+                                                             writer:passNil];
   XCTAssertNil(writer);
-
-  writer = [[GTMLoggerRingBufferWriter alloc] init];
-  XCTAssertNil(writer);
-
 }  // testCreation
 
 

--- a/Foundation/GTMScriptRunner.h
+++ b/Foundation/GTMScriptRunner.h
@@ -18,6 +18,8 @@
 
 #import <Foundation/Foundation.h>
 
+NS_ASSUME_NONNULL_BEGIN
+
 /// Encapsulates the interaction with an interpreter for running scripts.
 // This class manages the interaction with some command-line interpreter (e.g.,
 // a shell, perl, python) and allows you to run expressions through the
@@ -71,14 +73,15 @@
 //
 + (instancetype)runnerWithInterpreter:(NSString *)interp;
 + (instancetype)runnerWithInterpreter:(NSString *)interp
-                             withArgs:(NSArray *)args;
+                             withArgs:(nullable NSArray *)args;
 
 // Returns a GTMScriptRunner associated with |interp|
 - (instancetype)initWithInterpreter:(NSString *)interp;
 
 // Returns a GTMScriptRunner associated with |interp| and |args| applied to the
 // specified interpreter.  This method is the designated initializer.
-- (instancetype)initWithInterpreter:(NSString *)interp withArgs:(NSArray *)args;
+- (instancetype)initWithInterpreter:(NSString *)interp
+                           withArgs:(nullable NSArray *)args;
 
 // Runs the specified command string by sending it through the interpreter's
 // standard input.  The standard output is returned.  The standard error is
@@ -86,20 +89,23 @@
 - (NSString *)run:(NSString *)cmds;
 // Same as the previous method, except the standard error is returned in |err|
 // if specified.
-- (NSString *)run:(NSString *)cmds standardError:(NSString **)err;
+- (NSString *)run:(NSString *)cmds
+    standardError:(NSString * _Nullable __autoreleasing * _Nullable)err;
 
 // Runs the file at |path| using the interpreter.
 - (NSString *)runScript:(NSString *)path;
 // Runs the file at |path|, passing it |args| as arguments.
-- (NSString *)runScript:(NSString *)path withArgs:(NSArray *)args;
+- (NSString *)runScript:(NSString *)path
+               withArgs:(nullable NSArray *)args;
 // Same as above, except the standard error is returned in |err| if specified.
-- (NSString *)runScript:(NSString *)path withArgs:(NSArray *)args
-          standardError:(NSString **)err;
+- (NSString *)runScript:(NSString *)path
+               withArgs:(nullable NSArray *)args
+          standardError:(NSString * _Nullable __autoreleasing * _Nullable)err;
 
 // Returns the environment dictionary to use for the inferior process that will
 // run the interpreter. A return value of nil means that the interpreter's
 // environment should be erased.
-- (NSDictionary *)environment;
+- (nullable NSDictionary *)environment;
 
 // Sets the environment dictionary to use for the interpreter process. See
 // NSTask's -setEnvironment: documentation for details about the dictionary.
@@ -120,7 +126,7 @@
 // attacker can modify the environment that would then get sent to your scripts.
 // And if your binary is suid, then  you ABSOLUTELY should not do this.
 //
-- (void)setEnvironment:(NSDictionary *)newEnv;
+- (void)setEnvironment:(nullable NSDictionary *)newEnv;
 
 // Sets (and returns) whether or not whitespace is automatically trimmed from
 // the ends of the returned strings.  The default is YES, so trailing newlines
@@ -129,3 +135,5 @@
 - (void)setTrimsWhitespace:(BOOL)trim;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/Foundation/GTMScriptRunner.m
+++ b/Foundation/GTMScriptRunner.m
@@ -45,7 +45,7 @@ static BOOL LaunchNSTaskCatchingExceptions(NSTask *task);
 }
 
 - (instancetype)init {
-  return [self initWithInterpreter:nil];
+  return [self initWithInterpreter:@"/bin/sh"];
 }
 
 - (instancetype)initWithInterpreter:(NSString *)interp {
@@ -77,7 +77,7 @@ static BOOL LaunchNSTaskCatchingExceptions(NSTask *task);
 }
 
 - (NSString *)run:(NSString *)cmds {
-  return [self run:cmds standardError:nil];
+  return [self run:cmds standardError:NULL];
 }
 
 - (NSString *)run:(NSString *)cmds standardError:(NSString **)err {
@@ -259,7 +259,7 @@ static BOOL LaunchNSTaskCatchingExceptions(NSTask *task);
 }
 
 - (NSString *)runScript:(NSString *)path withArgs:(NSArray *)args {
-  return [self runScript:path withArgs:args standardError:nil];
+  return [self runScript:path withArgs:args standardError:NULL];
 }
 
 - (NSString *)runScript:(NSString *)path withArgs:(NSArray *)args standardError:(NSString **)err {

--- a/Foundation/GTMScriptRunnerTest.m
+++ b/Foundation/GTMScriptRunnerTest.m
@@ -230,7 +230,10 @@
   XCTAssertNotNil(sr, @"Script runner must not be nil");
   NSString *err = nil;
 
-  XCTAssertNil([sr run:nil standardError:&err]);
+  // Ensure passing nil doesn't crash, even though it shouldn't be done.
+  id passNil = nil;
+
+  XCTAssertNil([sr run:passNil standardError:&err]);
   XCTAssertNil(err);
 }
 
@@ -239,7 +242,10 @@
   XCTAssertNotNil(sr, @"Script runner must not be nil");
   NSString *err = nil;
 
-  XCTAssertNil([sr runScript:nil withArgs:nil standardError:&err]);
+  // Ensure passing nil doesn't crash, even though it shouldn't be done.
+  id passNil = nil;
+
+  XCTAssertNil([sr runScript:passNil withArgs:nil standardError:&err]);
   XCTAssertNil(err);
   XCTAssertNil([sr runScript:@"/path/that/does/not/exists/foo/bar/baz"
                     withArgs:nil standardError:&err]);
@@ -253,7 +259,10 @@
   XCTAssertNotNil(sr, @"Script runner must not be nil");
   NSString *err = nil;
 
-  XCTAssertNil([sr run:nil standardError:&err]);
+  // Ensure passing nil doesn't crash, even though it shouldn't be done.
+  id passNil = nil;
+
+  XCTAssertNil([sr run:passNil standardError:&err]);
   XCTAssertNil(err);
   XCTAssertNil([sr run:@"ls /" standardError:&err]);
   XCTAssertNil(err);


### PR DESCRIPTION
Use testing `id` workaround to keep tests and handling for `nil` even though some apis are now marked as not taking `nil`.