### PR TITLE
Add some Swift names.

### DIFF
--- a/Foundation/GTMLogger+ASL.h
+++ b/Foundation/GTMLogger+ASL.h
@@ -20,7 +20,6 @@
 #import <asl.h>
 #import "GTMLogger.h"
 
-
 // GTMLogger (GTMLoggerASLAdditions)
 //
 // Adds a convenience creation method that allows you to get a standard
@@ -31,7 +30,7 @@
 
 // Returns a new autoreleased GTMLogger instance that will log to ASL, using
 // the GTMLogASLFormatter, and the GTMLogLevelFilter filter.
-+ (instancetype)standardLoggerWithASL;
++ (instancetype)standardLoggerWithASL NS_SWIFT_NAME(standardWithASL());
 
 @end
 

--- a/Foundation/GTMLogger+ASL.m
+++ b/Foundation/GTMLogger+ASL.m
@@ -19,7 +19,6 @@
 #import "GTMLogger+ASL.h"
 #import "GTMDefines.h"
 
-
 @implementation GTMLogger (GTMLoggerASLAdditions)
 
 + (instancetype)standardLoggerWithASL {

--- a/Foundation/GTMLogger.h
+++ b/Foundation/GTMLogger.h
@@ -236,16 +236,16 @@
 + (instancetype)standardLogger;
 
 // Same as +standardLogger, but logs to stderr.
-+ (instancetype)standardLoggerWithStderr;
++ (instancetype)standardLoggerWithStderr NS_SWIFT_NAME(standardWithStderr());
 
 // Same as +standardLogger but levels >= kGTMLoggerLevelError are routed to
 // stderr, everything else goes to stdout.
-+ (instancetype)standardLoggerWithStdoutAndStderr;
++ (instancetype)standardLoggerWithStdoutAndStderr NS_SWIFT_NAME(standardWithStdoutAndStderr());
 
 // Returns a new standard GTMLogger instance with a log writer that will
 // write to the file at |path|, and will use the GTMLogStandardFormatter and
 // GTMLogLevelFilter classes. If |path| does not exist, it will be created.
-+ (instancetype)standardLoggerWithPath:(NSString *)path;
++ (instancetype)standardLoggerWithPath:(NSString *)path NS_SWIFT_NAME(standard(path:));
 
 // Returns an autoreleased GTMLogger instance that will use the specified
 // |writer|, |formatter|, and |filter|.
@@ -523,4 +523,3 @@ typedef enum {
                   level:(GTMLoggerLevel)level NS_FORMAT_FUNCTION(2, 0);
 
 @end
-


### PR DESCRIPTION
Now that things use `instancetype` the naming of some apis is better, this tweaks the names of the other apis that didn't change via the importer to remain aligned with the new style.