### PR TITLE
Add nullability annotations.

### DIFF
--- a/Foundation/GTMNSString+XML.h
+++ b/Foundation/GTMNSString+XML.h
@@ -22,27 +22,25 @@
 @interface NSString (GTMNSStringXMLAdditions)
 
 /// Get a string where characters that need escaping for XML are escaped and invalid characters removed
-//
+///
 /// This call escapes '&', '<, '>', '\'', '"' per the xml spec and removes all
 /// invalid characters as defined by Section 2.2 of the xml spec.
 ///
 /// For obvious reasons this call is only safe once.
-//
-//  Returns:
-//    Autoreleased NSString
-//
+///
+///  Returns:
+///    Autoreleased NSString.
 - (NSString *)gtm_stringBySanitizingAndEscapingForXML;
 
 /// Get a string where characters that invalid characters per the XML spec have been removed
-//
+///
 /// This call removes all invalid characters as defined by Section 2.2 of the
 /// xml spec.  If you are writing XML yourself, you probably was to use the
 /// above api (gtm_stringBySanitizingAndEscapingForXML) so any entities also
 /// get escaped.
-//
-//  Returns:
-//    Autoreleased NSString
-//
+///
+///  Returns:
+///    Autoreleased NSString.
 - (NSString *)gtm_stringBySanitizingToXMLSpec;
 
 // There is no stringByUnescapingFromXML because the XML parser will do this.

--- a/Foundation/GTMNSString+XML.m
+++ b/Foundation/GTMNSString+XML.m
@@ -16,6 +16,8 @@
 //  the License.
 //
 
+#include <stdlib.h>
+
 #import "GTMDefines.h"
 #import "GTMNSString+XML.h"
 
@@ -117,7 +119,9 @@ static NSString *AutoreleasedCloneForXML(NSString *src, BOOL escaping) {
     if (!data) {
       // COV_NF_START  - Memory fail case
       _GTMDevLog(@"couldn't alloc buffer");
-      return nil;
+      // If we can't get enough memory for the buffy copy, odds are finalString
+      // will also run out of memory, so just give up.
+      abort();
       // COV_NF_END
     }
     [src getCharacters:[data mutableBytes]];


### PR DESCRIPTION
If the temp buffer fails, just abort, as odds are other things will also run out of memory also.