### PR TITLE
Drop the `ceil` calls.

### DIFF
--- a/iPhone/GTMFadeTruncatingLabel.m
+++ b/iPhone/GTMFadeTruncatingLabel.m
@@ -53,9 +53,6 @@
   CGSize size = CGSizeZero;
   if (self.font) {
     size = [self.text sizeWithAttributes:@{NSFontAttributeName:self.font}];
-    // sizeWithAttributes: may return fractional values, so ceil the width and
-    // height to preserve the behavior of sizeWithFont:.
-    size = CGSizeMake(ceil(size.width), ceil(size.height));
   }
   if (size.width > requestedRect.size.width) {
     UIImage* image = [[self class]


### PR DESCRIPTION
The `ceil` calls were added back when updating things for iOS 7, to model what the older `-sizeWithFont:` call did. But looking back, Apple likely moved off the api (and behavior) with the adoption of retina screens, so we should do the fade calc based on the fractional sizes also, so we don't force a fade when the string fully fits.