### PR TITLE
Re-add (blank) WORKSPACE

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,0 +1,6 @@
+# Needed to enable quick local debugging via local_repository in other
+# WORKSPACE-based projects.
+# Why? local_repository doesn't work without a WORKSPACE, and 
+# new_local_repository requires overwriting the BUILD file (as of Bazel 7).
+
+# Dependencies have been migrated to bzlmod's MODULE.bazel.


### PR DESCRIPTION
Re-enables easier local debugging for people depending on GTM via the traditional WORKSPACE route.

[Sorry this is late-breaking. This bit of polish occurred *just* after you'd merged, but I thought it was still worthwhile to help you get high quality PRs.]