### PR TITLE
Bump major version instead.

### DIFF
--- a/GoogleToolboxForMac.podspec
+++ b/GoogleToolboxForMac.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'GoogleToolboxForMac'
-  s.version          = '3.1.0'
+  s.version          = '4.0.0'
   s.author           = 'Google Inc.'
   s.license          = { :type => 'Apache', :file => 'LICENSE' }
   s.homepage         = 'https://github.com/google/google-toolbox-for-mac'


### PR DESCRIPTION
Since the repo has remove deprecated apis and moves some things from `id` to `instancetype` this could be source breaking to some folks, so major version change is called for.