### PR TITLE
Delete .bazelrc now that Bazel 7 is released

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,2 +1,0 @@
-# Remove after Bazel 7.0 is released and bzlmod is enabled by default
-common --enable_bzlmod

--- a/BUILD
+++ b/BUILD
@@ -4,7 +4,6 @@ load("@build_bazel_rules_apple//apple:macos.bzl", "macos_build_test")
 objc_library(
     name = "Defines",
     hdrs = ["GTMDefines.h"],
-    includes = ["."],
     visibility = ["//visibility:public"],
 )
 

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -5,3 +5,6 @@ module(
 )
 
 bazel_dep(name = "rules_apple", version = "3.1.1", repo_name = "build_bazel_rules_apple")
+
+# Workaround https://github.com/bazelbuild/bazel/issues/20537
+bazel_dep(name = "apple_support", version = "1.11.1", repo_name = "build_bazel_apple_support")


### PR DESCRIPTION
bzlmod is now enabled by default. Follows up on #412, cleaning things up :)

(Hopefully the GitHub images have been updated to 7.0 and the tests will pass. If not, maybe rerun in a month--still worth my posting the PR, I think, so we don't forget to do this cleanup at some point.)

Cheers,
Chris 