### PR TITLE
Add scheduled CI runs to ensure things stay working.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,6 +5,11 @@ on:
     branches: [ main ]
   pull_request:
     branches: [ main ]
+  schedule:
+    # Run the first and fifteenth of every month at 5:12 UTC
+    - cron:  '12 4 1,15 * *'
+  # Also allow manual triggering from the github UX to revalidate things.
+  workflow_dispatch:
 
 jobs:
   macOS:


### PR DESCRIPTION
This should help catch/validate things as the runners update with new Xcodes, etc.