### PR TITLE
Fix gtm_imageByRotating (#541)

### DIFF
--- a/iPhone/GTMUIImage+Resize.m
+++ b/iPhone/GTMUIImage+Resize.m
@@ -159,7 +159,7 @@ GTM_INLINE CGSize swapWidthAndHeight(CGSize size) {
 
   UIGraphicsImageRendererFormat *rendererFormat = [[UIGraphicsImageRendererFormat alloc] init];
   rendererFormat.scale = self.scale;
-  UIGraphicsImageRenderer *renderer = [[UIGraphicsImageRenderer alloc] initWithSize:self.size
+  UIGraphicsImageRenderer *renderer = [[UIGraphicsImageRenderer alloc] initWithSize:bounds.size
                                                                              format:rendererFormat];
   UIImage *rotatedImage =
       [renderer imageWithActions:^(UIGraphicsImageRendererContext *_Nonnull rendererContext) {

--- a/iPhone/GTMUIImage+ResizeTest.m
+++ b/iPhone/GTMUIImage+ResizeTest.m
@@ -239,21 +239,36 @@
   UIImage *landscapeImage = [self testImageNamed:@"GTMUIImage+Resize_100x50"];
   XCTAssertNotNil(landscapeImage, @"Unable to read image.");
 
+  CGSize size50x100 = CGSizeMake(50, 100);
+  CGSize size100x50 = CGSizeMake(100, 50);
+
   // Rotate 90 degrees.
   UIImage *actual = [landscapeImage gtm_imageByRotating:UIImageOrientationRight];
   XCTAssertNotNil(actual);
+  XCTAssertTrue(CGSizeEqualToSize([actual size], size50x100),
+                @"Resized image should equal size: %@ actual: %@", NSStringFromCGSize(size50x100),
+                NSStringFromCGSize([actual size]));
 
   // Rotate 180 degrees.
   actual = [landscapeImage gtm_imageByRotating:UIImageOrientationDown];
   XCTAssertNotNil(actual);
+  XCTAssertTrue(CGSizeEqualToSize([actual size], size100x50),
+                @"Resized image should equal size: %@ actual: %@", NSStringFromCGSize(size100x50),
+                NSStringFromCGSize([actual size]));
 
   // Rotate 270 degrees.
   actual = [landscapeImage gtm_imageByRotating:UIImageOrientationLeft];
   XCTAssertNotNil(actual);
+  XCTAssertTrue(CGSizeEqualToSize([actual size], size50x100),
+                @"Resized image should equal size: %@ actual: %@", NSStringFromCGSize(size50x100),
+                NSStringFromCGSize([actual size]));
 
   // Rotate 360 degrees.
   actual = [landscapeImage gtm_imageByRotating:UIImageOrientationUp];
   XCTAssertNotNil(actual);
+  XCTAssertTrue(CGSizeEqualToSize([actual size], size100x50),
+                @"Resized image should equal size: %@ actual: %@", NSStringFromCGSize(size100x50),
+                NSStringFromCGSize([actual size]));
 }
 
 @end


### PR DESCRIPTION
Fix the new implementation that was added in c5ac5c2.

Update the unit tests to at least check the output dimensions. The updated unit tests fail before this change and succeed with the change.