### PR TITLE
Change `__weak` to `__unsafe_unretained` for the KVO target.

### DIFF
--- a/Foundation/GTMNSObject+KeyValueObserving.m
+++ b/Foundation/GTMNSObject+KeyValueObserving.m
@@ -66,10 +66,16 @@
 @end
 
 @interface GTMKeyValueObservingHelper : NSObject {
+  // observer_ is weak so if the observer is dealloc'd without being removed it should
+  // be a no-op if the value is modified. This is just to be safe.
   __weak id observer_;
   SEL selector_;
   id userInfo_;
-  __weak id target_;
+  // target_ is _unsafe_unretained to prevent retain loops if self is observing self.
+  // It is intentionally not _weak so that one can call `deregister` in dealloc.
+  // In some versions of iOS _weak pointers are set to nil *before* dealloc is called on
+  // the object, which means that the `deregister` method would fail.
+  __unsafe_unretained id target_;
   NSString* keyPath_;
 }
 

--- a/Foundation/GTMNSObject+KeyValueObservingTest.m
+++ b/Foundation/GTMNSObject+KeyValueObservingTest.m
@@ -44,6 +44,37 @@
 
 @end
 
+static BOOL gSelfReferencingKVODeallocCalled = NO;
+
+@interface SelfReferencingKVO : NSObject
+@property(nonatomic) int count;
+@property(nonatomic) BOOL sawSelf;
+@end
+
+@implementation SelfReferencingKVO
+- (instancetype)init {
+  self = [super init];
+  [self gtm_addObserver:self
+             forKeyPath:GTM_SEL_STRING(count)
+               selector:@selector(countDidChange:)
+               userInfo:nil
+                options:0];
+  return self;
+}
+
+- (void)dealloc {
+  [self gtm_stopObservingAllKeyPaths];
+  // This verifies that KVO has been deregistered.
+  XCTAssertNil([self observationInfo], @"%@", [self observationInfo]);
+  gSelfReferencingKVODeallocCalled = YES;
+}
+
+- (void)countDidChange:(GTMKeyValueChangeNotification *)notification {
+  self.sawSelf = YES;
+}
+
+@end
+
 @implementation GTMNSObject_KeyValueObservingTest
 - (void)setUp {
   dict_ = [[NSMutableDictionary alloc] initWithObjectsAndKeys:
@@ -118,6 +149,20 @@
   GTMKeyValueChangeNotification *copy = [notification copy];
   XCTAssertEqualObjects(notification, copy);
   XCTAssertEqual([notification hash], [copy hash]);
+}
+
+- (void)testSelfReferencingKVO {
+  // This test is for verifying that the KVO code does not cause a self-retain cycle, and that
+  // the KVO is properly cleaned up when the object is deallocated.
+  // See assert in [SelfReferencingKVO dealloc] that verifies that KVO has been deregistered.
+  SelfReferencingKVO *selfReferencingKVO = [[SelfReferencingKVO alloc] init];
+  XCTAssertEqual(selfReferencingKVO.count, 0);
+  selfReferencingKVO.count = 1;
+  XCTAssertEqual(selfReferencingKVO.count, 1);
+  XCTAssertEqual(selfReferencingKVO.sawSelf, YES);
+  XCTAssertFalse(gSelfReferencingKVODeallocCalled);
+  selfReferencingKVO = nil;
+  XCTAssertTrue(gSelfReferencingKVODeallocCalled);
 }
 
 @end


### PR DESCRIPTION
This change addresses potential issues with weak references in the KVO helper and adds a test case to verify that self-observing objects are properly deallocated and their KVO registrations are cleaned up.