### PR TITLE
Stop selecting the latest Xcode and use the image default.

### DIFF
--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -50,10 +50,6 @@ jobs:
         MODE: ["dbg", "opt"]
     steps:
     - uses: actions/checkout@v5
-    - name: Select Xcode Version
-      uses: maxim-lobanov/setup-xcode@v1
-      with:
-        xcode-version: 'latest-stable'
     - uses: bazel-contrib/setup-bazel@0.15.0
       with:
         bazelisk-cache: true

--- a/.github/workflows/cocoapods.yml
+++ b/.github/workflows/cocoapods.yml
@@ -45,10 +45,6 @@ jobs:
         CONFIGURATION: ["Debug", "Release"]
     steps:
     - uses: actions/checkout@v5
-    - name: Select Xcode Version
-      uses: maxim-lobanov/setup-xcode@v1
-      with:
-        xcode-version: 'latest-stable'
     - name: Pod lib lint
       run:  |
         pod lib lint --verbose \

--- a/.github/workflows/xcode.yml
+++ b/.github/workflows/xcode.yml
@@ -46,10 +46,6 @@ jobs:
         MODE: ["Debug", "Release"]
     steps:
     - uses: actions/checkout@v5
-    - name: Select Xcode Version
-      uses: maxim-lobanov/setup-xcode@v1
-      with:
-        xcode-version: 'latest-stable'
     - name: Build and Test
       run:  |
         xcodebuild \
@@ -65,10 +61,6 @@ jobs:
         MODE: ["Debug", "Release"]
     steps:
     - uses: actions/checkout@v5
-    - name: Select Xcode Version
-      uses: maxim-lobanov/setup-xcode@v1
-      with:
-        xcode-version: 'latest-stable'
     - name: Build and Test
       run:  |
         xcodebuild \


### PR DESCRIPTION
The latest GitHub images have the 26 RC, but they didn't install any defaults with that OS, so it makes actions fail. So just go back to using the default Xcode on the images.