### PR TITLE
[spm] Fix for Swift 6.0 compatibility

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -74,7 +74,7 @@ let package = Package(
       path: "UnitTesting/SenTestCase",
       exclude: [
         "GTMSenTestCaseTest.m"
-      ],
+      ]
     ),
     .testTarget(
       name: "GTMLoggerTests",


### PR DESCRIPTION
Swift 6.1 (Xcode 16.3+) adds broader support for trailing commas in
function call argument lists (see SE-0439), but Swift 6.0 is stricter.
Package.swift used a trailing comma after the last argument in a
`.testTarget()` call, which is invalid syntax for that version.
This change removes the trailing comma to ensure
the package manifest can be parsed correctly by Swift 6.0.