### PR TITLE
[SPM] Workaround for header only GTMDefines SPM module

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -20,7 +20,7 @@ let package = Package(
     .library(
       name: "GTMStringEncoding",
       targets: ["GTMStringEncoding"]
-    ),
+    )
   ],
   targets: [
     .target(
@@ -74,7 +74,7 @@ let package = Package(
       path: "UnitTesting/SenTestCase",
       exclude: [
         "GTMSenTestCaseTest.m"
-      ],
+      ]
     ),
     .testTarget(
       name: "GTMLoggerTests",
@@ -101,6 +101,6 @@ let package = Package(
       exclude: [
         "BUILD"
       ]
-    ),
+    )
   ]
 )

--- a/Sources/Defines/GTMDefines.m
+++ b/Sources/Defines/GTMDefines.m
@@ -1,0 +1,25 @@
+//
+// GTMDefines.m
+//
+//  Copyright 2008 Google Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License"); you may not
+//  use this file except in compliance with the License.  You may obtain a copy
+//  of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+//  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+//  License for the specific language governing permissions and limitations under
+//  the License.
+//
+
+// ============================================================================
+
+// This file exists only to trigger the module to build; without
+// it swiftpm won't build anything, and then the package is not available for
+// the modules that need it.
+
+#include <GTMDefines.h>


### PR DESCRIPTION
- added dummy source file for GTMDefines SPM module to mitigate https://github.com/swiftlang/swift-package-manager/issues/5706
- removed extra commas from Package.swift which were causing compatibility issues with Swift toolset bundled within Xcode 16.2